### PR TITLE
Add server route to .env variable

### DIFF
--- a/.env
+++ b/.env
@@ -50,3 +50,5 @@ REACT_APP_OPENSHIFT_VERSION_RELEASE_HOME_PAGE = openshift-4.8
 
 # run environment
 REACT_APP_RUN_ENV=production
+
+REACT_APP_ART_DASH_SERVER_ROUTE = http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com

--- a/src/api_calls/build_calls.js
+++ b/src/api_calls/build_calls.js
@@ -3,7 +3,7 @@ let server_endpoint = null
 if (process.env.REACT_APP_RUN_ENV === "dev"){
     server_endpoint = "http://localhost:8000/"
 }else{
-    server_endpoint = process.env.ART_DASH_SERVER_ROUTE + "/"
+    server_endpoint = process.env.REACT_APP_ART_DASH_SERVER_ROUTE + "/"
 }
 
 export async function auto_complete_nvr() {

--- a/src/api_calls/build_health_calls.js
+++ b/src/api_calls/build_health_calls.js
@@ -3,7 +3,7 @@ let server_endpoint = null
 if (process.env.REACT_APP_RUN_ENV === "dev"){
     server_endpoint = "http://localhost:8000/"
 }else{
-    server_endpoint = process.env.ART_DASH_SERVER_ROUTE + "/"
+    server_endpoint = process.env.REACT_APP_ART_DASH_SERVER_ROUTE + "/"
 }
 
 

--- a/src/api_calls/incident_calls.js
+++ b/src/api_calls/incident_calls.js
@@ -3,7 +3,7 @@ let server_endpoint = null
 if (process.env.REACT_APP_RUN_ENV === "dev"){
     server_endpoint = "http://localhost:8000/"
 }else{
-    server_endpoint = process.env.ART_DASH_SERVER_ROUTE + "/"
+    server_endpoint = process.env.REACT_APP_ART_DASH_SERVER_ROUTE + "/"
 }
 
 export async function get_all_incident_reports() {

--- a/src/api_calls/release_calls.js
+++ b/src/api_calls/release_calls.js
@@ -3,7 +3,7 @@ let server_endpoint = null
 if (process.env.REACT_APP_RUN_ENV === "dev"){
     server_endpoint = "http://localhost:8000/"
 }else{
-    server_endpoint = process.env.ART_DASH_SERVER_ROUTE + "/"
+    server_endpoint = process.env.REACT_APP_ART_DASH_SERVER_ROUTE + "/"
 }
 
 


### PR DESCRIPTION
React is autofilling the URL in fetch because its getting an undefined value while trying to read the env variable. 
`http://art-dash.engineering.redhat.com/release/status/undefined//release/branch?type=all` is what we see while trying to see the network traffic in the browser. Hopefully by adding this value in .env, React will be able to get access.