### PR TITLE
add REACT_APP_ART_DASH_SERVER_ROUTE to env

### DIFF
--- a/.env
+++ b/.env
@@ -50,3 +50,5 @@ REACT_APP_OPENSHIFT_VERSION_RELEASE_HOME_PAGE = openshift-4.8
 
 # run environment
 REACT_APP_RUN_ENV=production
+
+REACT_APP_ART_DASH_SERVER_ROUTE = http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com


### PR DESCRIPTION
React is autofilling the URL in fetch because its getting an undefined value while trying to read the env variable.
`http://art-dash.engineering.redhat.com/release/status/undefined//release/branch?type=all` is what we see while trying to see the network traffic in the browser. Hopefully by adding this value in .env, React will be able to get access.