### PR TITLE
Add permission for .next folder

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,6 +17,9 @@ RUN npm install
 # add app
 COPY . ./
 EXPOSE 8080
+
+RUN chmod -R 0777 .next
+
 # start app
 USER 0
 CMD ["next","dev", "-p", "8080"]


### PR DESCRIPTION
The next folder gets created when next dev is run, hence give permissions for all users.