### PR TITLE
set OPENSHIFT_BUILD_NAMESPACE in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ WORKDIR /app
 # add `/app/node_modules/.bin` to $PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
+# Set default namespace to aos-art-web
+# This value is overriden by the build config argument in art-build-dev namespace
+ARG OPENSHIFT_BUILD_NAMESPACE=aos-art-web
+
+# To expose env variables to the browser, nextjs requeires the variable to be prepended with NEXT_PUBLIC
+ENV NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE=$OPENSHIFT_BUILD_NAMESPACE
+
 # install app dependencies
 COPY package.json ./
 COPY package-lock.json ./

--- a/components/api_calls/build_calls.js
+++ b/components/api_calls/build_calls.js
@@ -6,7 +6,7 @@ if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE + "/"
 
     // OPENSHIFT_BUILD_NAMESPACE env variable is obtained inside pod during its run
-    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.OPENSHIFT_BUILD_NAMESPACE);
+    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE);
 }
 
 export async function auto_complete_nvr() {

--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -6,7 +6,7 @@ if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE + "/"
 
     // OPENSHIFT_BUILD_NAMESPACE env variable is obtained inside pod during its run
-    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.OPENSHIFT_BUILD_NAMESPACE);
+    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE);
 }
 
 


### PR DESCRIPTION
Since nextjs is not reading the pod env variables, the next best solution is to define the variable in the Dockerfile and override the variable in build config build args.