### PR TITLE
Remove server route for art-build-dev

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 # This file gets loaded when the command 'next start' is run. Values in .env.local, overrides values in this file
 
-NEXT_PUBLIC_ART_DASH_SERVER_ROUTE=http://art-dash-server-{0}.apps.ocp4.prod.psi.redhat.com
+NEXT_PUBLIC_ART_DASH_SERVER_ROUTE=http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,6 @@ WORKDIR /app
 # add `/app/node_modules/.bin` to $PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
-# Set default namespace to aos-art-web
-# This value is overriden by the build config argument in art-build-dev namespace
-ARG OPENSHIFT_BUILD_NAMESPACE=aos-art-web
-
-# To expose env variables to the browser, nextjs requeires the variable to be prepended with NEXT_PUBLIC
-ENV NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE=$OPENSHIFT_BUILD_NAMESPACE
-
 # install app dependencies
 COPY package.json ./
 COPY package-lock.json ./

--- a/components/api_calls/build_calls.js
+++ b/components/api_calls/build_calls.js
@@ -4,9 +4,6 @@ if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
     server_endpoint = "http://localhost:8080"
 } else {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE + "/"
-
-    // OPENSHIFT_BUILD_NAMESPACE env variable is obtained inside pod during its run
-    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE);
 }
 
 export async function getBuilds(searchParams) {

--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -4,9 +4,6 @@ if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
     server_endpoint = "http://localhost:8080/"
 } else {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE + "/"
-
-    // OPENSHIFT_BUILD_NAMESPACE env variable is obtained inside pod during its run
-    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE);
 }
 
 


### PR DESCRIPTION
Now that we're migrating to the new cluster, we don't need to have two configurations for server in prod and dev