### PR TITLE
Feature Addition: RPMs and Images List Component

### DIFF
--- a/components/api_calls/rpms_images_fetcher_calls.js
+++ b/components/api_calls/rpms_images_fetcher_calls.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+let server_endpoint = null
+
+if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
+    server_endpoint = "http://localhost:8080/"
+} else {
+    server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE + "/"
+
+    // OPENSHIFT_BUILD_NAMESPACE env variable is obtained inside pod during its run
+    server_endpoint = server_endpoint.replace(/\{0\}/g, process.env.NEXT_PUBLIC_OPENSHIFT_BUILD_NAMESPACE);
+}
+
+export function fetchRpmsImages(branchName) {
+    const url = `${server_endpoint}api/v1/rpms_images_fetcher?release=${branchName}`;
+    return axios.get(url)
+    .then(response => response.data)
+    .catch(error => console.error('Error:', error));
+}

--- a/components/release/RpmsImagesList.js
+++ b/components/release/RpmsImagesList.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { fetchRpmsImages } from '../api_calls/rpms_images_fetcher_calls';
+import { Spin, Table, Row, Col, Input } from 'antd';
+
+const { Search } = Input;
+
+export default function RpmsImagesList({ branch }) {
+  const [rpmsImagesData, setRpmsImagesData] = useState(null);
+  const [searchedRpm, setSearchedRpm] = useState('');
+  const [searchedImage, setSearchedImage] = useState('');
+
+  useEffect(() => {
+    fetchRpmsImages(branch)
+      .then(data => {
+        setRpmsImagesData(data.payload);
+      })
+      .catch(error => console.error('Error:', error));
+  }, [branch]);
+
+  if (!rpmsImagesData) {
+    return <Spin />;
+  }
+
+  const rpmsData = rpmsImagesData[0].rpms_in_distgit
+    .filter(rpm => rpm.includes(searchedRpm))
+    .map((rpmName, index) => ({
+      key: index,
+      rpmName,
+    }));
+
+  const imagesData = rpmsImagesData[0].images_in_distgit
+    .filter(image => image.includes(searchedImage))
+    .map((imageName, index) => ({
+      key: index,
+      imageName,
+    }));
+
+  return (
+    <Row gutter={16}>
+      <Col span={12}>
+        <h2>RPMS</h2>
+        <Search
+          placeholder="Search RPM"
+          onChange={e => setSearchedRpm(e.target.value)}
+        />
+        <Table dataSource={rpmsData} columns={[{ title: 'RPM Name', dataIndex: 'rpmName', key: 'rpmName' }]} />
+      </Col>
+      <Col span={12}>
+        <h2>Images</h2>
+        <Search
+          placeholder="Search Image"
+          onChange={e => setSearchedImage(e.target.value)}
+        />
+        <Table dataSource={imagesData} columns={[{ title: 'Image Name', dataIndex: 'imageName', key: 'imageName' }]} pagination={{ pageSize: 40 }}/>
+      </Col>
+    </Row>
+  );
+}

--- a/components/release/openshift_version_select.js
+++ b/components/release/openshift_version_select.js
@@ -4,9 +4,8 @@ import {getReleaseBranchesFromOcpBuildData} from "../api_calls/release_calls";
 
 const {Option} = Select;
 
-function OpenshiftVersionSelect() {
+function OpenshiftVersionSelect({ onVersionChange, initialVersion, redirectOnSelect=false }) {
     const [data, setData] = useState([]);
-    const [onSelectVersion, setOnSelectVersion] = useState(undefined);
 
     const setDataFunc = () => {
         getReleaseBranchesFromOcpBuildData().then(loopData => {
@@ -20,14 +19,19 @@ function OpenshiftVersionSelect() {
     }
 
     const onChangeFunc = (value) => {
-        setOnSelectVersion(value);
+        if (redirectOnSelect) {
+            // Redirect to the version specific page
+            window.location.replace(`/dashboard/release/${value}`);
+        } else {
+            // Invoke the passed function
+            onVersionChange(value);
+        }
     }
 
     const generateSelectOptionFromStateDate = (stateData) => {
         return stateData.map((openshiftVersion) => {
-
             return (
-                <Option value={openshiftVersion}>{openshiftVersion}</Option>
+                <Option value={openshiftVersion} key={openshiftVersion}>{openshiftVersion}</Option>  // Add key prop
             )
         })
     }
@@ -36,18 +40,14 @@ function OpenshiftVersionSelect() {
         setDataFunc();
     }, [])
 
-    if (onSelectVersion === undefined) {
-        return (
-            <div align={"right"} style={{padding: "30px"}}>
-                <Select placeholder={<div style={{color: "black"}}>Openshift Version</div>} onChange={onChangeFunc}>
-                    {generateSelectOptionFromStateDate(data)}
-                </Select>
-            </div>
-
-        );
-    } else {
-        window.location.replace(`/dashboard/release/${onSelectVersion}`);
-    }
+    // Simplify the render function by removing the if-else
+    return (
+        <div align={"right"} style={{padding: "30px"}}>
+            <Select defaultValue={initialVersion} placeholder={<div style={{color: "black"}}>Openshift Version</div>} onChange={onChangeFunc}>
+                {generateSelectOptionFromStateDate(data)}
+            </Select>
+        </div>
+    );
 }
 
 export default OpenshiftVersionSelect;

--- a/pages/dashboard/build/history/index.js
+++ b/pages/dashboard/build/history/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {getBuilds} from "../../../../components/api_calls/build_calls";
 import BUILD_HISTORY_TABLE from "../../../../components/build/build_history_table"
-import {ReloadOutlined, RocketOutlined} from "@ant-design/icons";
+import {RocketOutlined, ReloadOutlined, FileImageOutlined} from "@ant-design/icons";
 import Head from "next/head";
 import {Layout, Menu} from "antd";
 
@@ -150,6 +150,11 @@ export default function BUILD_HISTORY_HOME() {
             key: "buildHistory",
             icon: <ReloadOutlined/>,
             label: <a href={"/dashboard/build/history"}><p style={{fontSize: "medium"}}>Build History</p></a>
+        },
+        {
+            key: "rpmImages",
+            icon: <FileImageOutlined/>, // replace MyIcon with an appropriate icon
+            label: <a href={"/dashboard/rpm_images"}><p style={{fontSize: "medium"}}>RPMs & Images</p></a>
         }
     ]
 

--- a/pages/dashboard/release/[releaseVersion].js
+++ b/pages/dashboard/release/[releaseVersion].js
@@ -5,7 +5,7 @@ import OPENSHIFT_VERSION_SELECT from "../../../components/release/openshift_vers
 import RELEASE_BRANCH_DETAIL from "../../../components/release/release_branch_detail"
 import {useRouter} from 'next/router'
 import Head from "next/head";
-import {RocketOutlined, ReloadOutlined} from "@ant-design/icons";
+import {RocketOutlined, ReloadOutlined, FileImageOutlined} from "@ant-design/icons";
 
 const {Title} = Typography;
 
@@ -55,6 +55,11 @@ function ReleaseHomePage() {
             key: "buildHistory",
             icon: <ReloadOutlined/>,
             label: <a href={"/dashboard/build/history"}><p style={{fontSize: "medium"}}>Build History</p></a>
+        },
+        {
+            key: "rpmImages",
+            icon: <FileImageOutlined/>, 
+            label: <a href={"/dashboard/rpm_images"}><p style={{fontSize: "medium"}}>RPMs & Images</p></a>
         }
     ]
 
@@ -95,7 +100,7 @@ function ReleaseHomePage() {
                                 :
                                 <Title style={{paddingLeft: 20}} level={2}><code>{releaseVersion}</code></Title>
                         }
-                        <OPENSHIFT_VERSION_SELECT branch={releaseVersion}/>
+                        <OPENSHIFT_VERSION_SELECT initialVersion={releaseVersion} redirectOnSelect />
                     </div>
                     <RELEASE_BRANCH_DETAIL branch={releaseVersion}
                                            destroyLoadingCallback={destroyLoading}/>

--- a/pages/dashboard/rpm_images/index.js
+++ b/pages/dashboard/rpm_images/index.js
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { Layout, Menu, message, Typography } from 'antd';
+import { RocketOutlined, ReloadOutlined, FileImageOutlined } from '@ant-design/icons';
+import Head from 'next/head';
+import OPENSHIFT_VERSION_SELECT from "../../../components/release/openshift_version_select";
+import ImagesList from "../../../components/release/RpmsImagesList";
+import {getReleaseBranchesFromOcpBuildData} from "../../../components/api_calls/release_calls";
+
+const { Title, Text } = Typography;
+const { Footer, Sider } = Layout;
+
+function RpmImages() {
+    const [selectedVersion, setSelectedVersion] = useState(null);
+    const [initialVersion, setInitialVersion] = useState(null);
+
+    useEffect(() => {
+        getReleaseBranchesFromOcpBuildData().then(loopData => {
+            const versions = loopData.map(detail => detail["name"]);
+            setInitialVersion(versions[0]); // set initial version to the latest version
+            setSelectedVersion(versions[0]); // start loading data for the latest version
+        });
+    }, []);
+
+    const menuItems = [
+        {
+            key: "releaseStatusMenuItem",
+            icon: <RocketOutlined />,
+            label: <a href={"/dashboard"}><p style={{fontSize: "medium"}}>Release status</p></a>
+        },
+        {
+            key: "buildHistory",
+            icon: <ReloadOutlined />,
+            label: <a href={"/dashboard/build/history"}><p style={{fontSize: "medium"}}>Build History</p></a>
+        },
+        {
+            key: "rpmImages",
+            icon: <FileImageOutlined />,
+            label: <a href={"/dashboard/rpm_images"}><p style={{fontSize: "medium"}}>RPMs & Images</p></a>
+        },
+    ];
+
+    return (
+        <div>
+            <Head>
+                <title>ART Dashboard</title>
+                <link rel="icon" href="/redhat-logo.png"/>
+            </Head>
+            <Layout>
+                <Sider collapsed={false}>
+                    <div style={{paddingTop: "10px"}}>
+                        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']} items={menuItems}/>
+                    </div>
+                </Sider>
+
+                <Layout>
+                    <div align={"center"} style={{background: "white", height: "120px", float: "left"}}>
+                        <div className="center">
+                            <h1 style={{color: "#316DC1", margin: "20px", fontSize: "4.2rem", fontWeight: "normal"}}>
+                                OpenShift Release Portal
+                            </h1>
+                        </div>
+                    </div>
+
+                    <div className={"version-header"} style={{ display: 'flex', justifyContent: 'space-between', padding: '30px' }}>
+                        {selectedVersion && 
+                            <h2 className="ant-typography" style={{ paddingLeft: '20px' }}>
+                                <code>{selectedVersion} </code>
+                            </h2>
+                        }
+                        <div align="right">
+                        <OPENSHIFT_VERSION_SELECT initialVersion={initialVersion} onVersionChange={setSelectedVersion} />
+                        </div>
+                    </div>
+
+                    {selectedVersion && <ImagesList branch={selectedVersion} />}
+                    
+                    <Footer style={{textAlign: 'center'}}>
+                        RedHat © 2023
+                    </Footer>
+                </Layout>
+            </Layout>
+        </div>
+    );
+}
+
+export default RpmImages;


### PR DESCRIPTION
1. Created the RpmsImagesList component which presents the list of RPMs and images in the application. The fetchRpmsImages function was added to the rpms_images_fetcher_calls.js file and is used to fetch the necessary data from the server endpoint based on the environment configuration.

2. Updated the OpenshiftVersionSelect component to make it more reusable and flexible. The component now takes in onVersionChange, initialVersion, and redirectOnSelect as props to adjust its behavior based on the use-case. In the previous implementation, the component used a local state to handle selection which caused a re-render and redirection in all cases. This update aims to improve the component's usability in different scenarios.

3. Modified the [releaseVersion].js file. A new menu item "RPMs & Images" was added , which redirects to the /dashboard/rpm_images page. (also added this to build/history/index.js) The redirection logic was also modified in the OpenshiftVersionSelect component. The redirection now depends on the redirectOnSelect prop and doesn't occur every time the selected version changes.

These changes aim to enhance user interaction with the RPMs and images list, and to increase code reuse and efficiency in the codebase.