### PR TITLE
Fix query parameter issues in API calls for build history

### DIFF
--- a/components/api_calls/build_calls.js
+++ b/components/api_calls/build_calls.js
@@ -21,6 +21,6 @@ export async function getBuilds(searchParams) {
         "Content-Type": "application/json"
     };
 
-    return makeApiCall(process.env.NEXT_PUBLIC_BUILD_ENDPOINT, 'GET', headers, params)
+    return makeApiCall(process.env.NEXT_PUBLIC_BUILD_ENDPOINT, 'GET', {}, headers, params)
         .catch(error => console.error('Error:', error));
 }

--- a/pages/dashboard/build/history/index.js
+++ b/pages/dashboard/build/history/index.js
@@ -73,7 +73,6 @@ export default function BUILD_HISTORY_HOME() {
 
     const getData = () => {
         searchParams["page"] = page
-
         if (buildNo !== "") {
             searchParams["build_0_id"] = buildNo
         } else {
@@ -131,9 +130,7 @@ export default function BUILD_HISTORY_HOME() {
         getBuilds(searchParams).then((data) => {
             setData(data["results"]);
             setTotalCount(data["count"]);
-
         });
-
     }
 
     useEffect(() => {


### PR DESCRIPTION
This commit addresses the issue of not correctly sending query parameters when making API calls for build history.

Changes:
- Updated the  function to properly include query parameters in the API call.
- Removed extraneous whitespace

These changes ensure that query parameters are correctly included in the API request, which in turn allows for accurate data retrieval from the server.