### PR TITLE
Integrate OCP bugs data into release page

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,3 @@ NEXT_PUBLIC_RUN_ENV=prod
 
 # art-dash server API endpoint
 NEXT_PUBLIC_API_ENDPOINT=api/v1
-
-# GA version
-NEXT_PUBLIC_GA_VERSION=4.13

--- a/components/api_calls/api_calls.js
+++ b/components/api_calls/api_calls.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+const axios = require('axios');
 
 // Setting axios defaults for CSRF token
 axios.defaults.xsrfCookieName = 'csrftoken';
@@ -19,7 +19,7 @@ function getCookie(cookies, name) {
     return null;
 }
 
-export function makeApiCall(urlPath, method, data = {}, headers = {}, params = {}, req = null) {
+function makeApiCall(urlPath, method, data = {}, headers = {}, params = {}, req = null) {
     if (!server_endpoint || !urlPath) {
         return;
     }
@@ -28,18 +28,17 @@ export function makeApiCall(urlPath, method, data = {}, headers = {}, params = {
         urlPath = '/' + urlPath;
     }
 
-    // Use the provided request object's cookies (if available) for server-side calls
+    let token;
     if (req) {
-        const token = getCookie(req.headers.cookie, 'token');
-        if (token) {
-            headers.Authorization = `Bearer ${token}`;
-        }
-    } else {
-        // For client-side calls, use the document object to fetch the cookie
-        const token = getCookie(document.cookie, 'token');
-        if (token) {
-            headers.Authorization = `Bearer ${token}`;
-        }
+        // Server-side
+        token = getCookie(req.headers.cookie, 'token');
+    } else if (typeof document !== 'undefined') {
+        // Client-side
+        token = getCookie(document.cookie, 'token');
+    }
+
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
     }
 
     const url = `${server_endpoint}${urlPath}`;
@@ -60,3 +59,7 @@ export function makeApiCall(urlPath, method, data = {}, headers = {}, params = {
         return { detail: 'Request failed' };
     });
 }
+
+module.exports = {
+    makeApiCall
+};

--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -1,36 +1,68 @@
-import { makeApiCall } from './api_calls';
+const { makeApiCall } = require('./api_calls');
 
 const headers = {
     'Accept': 'application/json',
     "Content-Type": "application/json"
 };
 
-export function getReleaseBranchesFromOcpBuildData() {
+function getReleaseBranchesFromOcpBuildData() {
     const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}${process.env.NEXT_PUBLIC_OCP_BUILD_DATA_OPENSHIFT_BRANCH_ENDPOINT}`;
     return makeApiCall(url, 'GET', headers);
 }
 
-export function remaining_git_requests() {
+function remaining_git_requests() {
     const url = `${process.env.NEXT_PUBLIC_GIT_HUB_RATE_LIMIT_ENDPOINT}`;
     return makeApiCall(url, 'GET', headers);
 }
 
-export function advisory_ids_for_branch(branch_name) {
+function advisory_ids_for_branch(branch_name) {
     const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}${process.env.NEXT_PUBLIC_CURRENT_ADVISORY_IDS_FOR_A_BRANCH_OCP_BUILD_DATA}${branch_name}`;
     return makeApiCall(url, 'GET', headers);
 }
 
-export function advisory_details_for_advisory_id(advisory_id) {
+function advisory_details_for_advisory_id(advisory_id) {
     const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}${process.env.NEXT_PUBLIC_ADVISORY_DETAILS_FOR_AN_ADVISORY_ID}${advisory_id}`;
     return makeApiCall(url, 'GET', headers);
 }
 
-export function user_details_for_user_id(user_id) {
+function user_details_for_user_id(user_id) {
     const url = `${process.env.NEXT_PUBLIC_USER_DETAILS_FOR_A_USER_ID}${user_id}`;
     return makeApiCall(url, 'GET', headers);
 }
 
-export function gaVersion() {
+function gaVersion() {
+    const currentTime = new Date().getTime();  // Moved the definition up
+
+    if (typeof localStorage !== 'undefined') {
+        const cachedGaVersion = localStorage.getItem('gaVersion');
+        const cachedTimestamp = localStorage.getItem('gaVersionTimestamp');
+        
+        const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
+        // If cached version exists and it's not older than a day
+        if (cachedGaVersion && cachedTimestamp && (currentTime - cachedTimestamp < oneDayInMilliseconds)) {
+            return Promise.resolve({ payload: cachedGaVersion });
+        } 
+    }
+    
+    // If localStorage is not available or cached data is stale
     const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/ga-version`;
-    return makeApiCall(url, 'GET', headers);
+    return makeApiCall(url, 'GET', headers)
+        .then(response => {
+            if (typeof localStorage !== 'undefined') {
+                // Save the new value and timestamp to local storage
+                localStorage.setItem('gaVersion', response.payload);
+                localStorage.setItem('gaVersionTimestamp', currentTime.toString());
+            }
+            return response;
+        });
 }
+
+module.exports = {
+    getReleaseBranchesFromOcpBuildData,
+    remaining_git_requests,
+    advisory_ids_for_branch,
+    advisory_details_for_advisory_id,
+    user_details_for_user_id,
+    gaVersion
+};

--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -43,7 +43,6 @@ function ReleaseBranchDetail(props) {
                 return FIXED_ORDER.indexOf(a.type) - FIXED_ORDER.indexOf(b.type);
             });
             
-            console.log("Sorted advisories_data: ", advisories_data);  // Debugging line
             setAdvisoryDetails(advisories_data);
         });
     };

--- a/components/release/release_branch_detail_table.js
+++ b/components/release/release_branch_detail_table.js
@@ -229,7 +229,10 @@ function ReleaseBranchDetailTable(props) {
 
                             return (
                                 <div key={index}>
-                                    <Badge count={bug_status["count"]}>
+                                    <Badge
+                                        count={bug_status["count"]}
+                                        overflowCount={99999}
+                                    >
                                         <Tag color={color} key={bug_status["bug_status"]}>
                                             {bug_status["bug_status"]}
                                         </Tag>

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,16 @@
+const { gaVersion } = require('./components/api_calls/release_calls');
 module.exports = {
     async redirects() {
+        const gaResponse = await gaVersion();
+        const currentGaVersion = gaResponse.payload;
+
         // Set redirect automatically to GA release version page
         return [
             {
                 source: '/dashboard',
-                destination: '/dashboard/release/openshift-' + process.env.NEXT_PUBLIC_GA_VERSION,
+                destination: `/dashboard/release/openshift-${currentGaVersion}`,
                 permanent: true,
             },
-        ]
-    },
-}
+        ];
+    }
+};

--- a/pages/dashboard/release/[releaseVersion].js
+++ b/pages/dashboard/release/[releaseVersion].js
@@ -1,17 +1,19 @@
 // File name defined as [releaseVersion].js to get the value from the parent component.
-import React, {useEffect} from "react";
+import React, { useEffect, useState } from "react";
 import {Layout, Menu, message, Typography} from "antd";
 import OPENSHIFT_VERSION_SELECT from "../../../components/release/openshift_version_select";
 import RELEASE_BRANCH_DETAIL from "../../../components/release/release_branch_detail"
 import {useRouter} from 'next/router'
 import Head from "next/head";
 import {RocketOutlined, ReloadOutlined, FileImageOutlined} from "@ant-design/icons";
+import { gaVersion } from "../../../components/api_calls/release_calls";
 
 const {Title} = Typography;
 
 function ReleaseHomePage() {
     const router = useRouter()
     const {releaseVersion} = router.query
+    const [gaVersionValue, setGaVersion] = useState(null);
 
     const {Footer, Sider} = Layout;
 
@@ -42,8 +44,14 @@ function ReleaseHomePage() {
 
     useEffect(() => {
         displayLoading();
-    }, [])
-
+        gaVersion()
+        .then(response => {
+            setGaVersion(response.payload);  // Adjusted this to use the correct property
+        })
+        .catch(error => {
+            console.error('Failed to fetch GA version:', error);
+        });
+    }, []);    
 
     const menuItems = [
         {
@@ -94,12 +102,12 @@ function ReleaseHomePage() {
                         </div>
                     </div>
                     <div className={"version-header"}>
-                        {
-                            releaseVersion === `openshift-${process.env.NEXT_PUBLIC_GA_VERSION}` ?
-                                <Title style={{paddingLeft: 20}} level={2}><code>{releaseVersion} (GA) </code></Title>
-                                :
-                                <Title style={{paddingLeft: 20}} level={2}><code>{releaseVersion}</code></Title>
-                        }
+                    {
+                        releaseVersion === `openshift-${gaVersionValue}` ?
+                            <Title style={{ paddingLeft: 20 }} level={2}><code>{releaseVersion} (GA) </code></Title>
+                            :
+                            <Title style={{ paddingLeft: 20 }} level={2}><code>{releaseVersion}</code></Title>
+                    }
                         <OPENSHIFT_VERSION_SELECT initialVersion={releaseVersion} redirectOnSelect />
                     </div>
                     <RELEASE_BRANCH_DETAIL branch={releaseVersion}

--- a/pages/dashboard/rpm_images/index.js
+++ b/pages/dashboard/rpm_images/index.js
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import OPENSHIFT_VERSION_SELECT from "../../../components/release/openshift_version_select";
 import ImagesList from "../../../components/release/RpmsImagesList";
 import {getReleaseBranchesFromOcpBuildData} from "../../../components/api_calls/release_calls";
+import { gaVersion } from "../../../components/api_calls/release_calls";
 
 const { Footer, Sider } = Layout;
 const { Title } = Typography;
@@ -17,6 +18,7 @@ function RpmImages() {
     const [selectedVersion, setSelectedVersion] = useState(null);
     const [initialVersion, setInitialVersion] = useState(null);
     const [loadingData, setLoadingData] = useState(true); // New loading state
+    const [gaVersionValue, setGaVersionValue] = useState(null);
 
     const menuItems = [
         {
@@ -42,14 +44,22 @@ function RpmImages() {
             setInitialVersion(versions[0]); // set initial version to the latest version
             setSelectedVersion(versions[0]); // start loading data for the latest version
         });
-
-        // Display the loading message without calling handleLoaded here
+    
+        gaVersion()
+            .then(response => {
+                setGaVersionValue(response.payload);
+            })
+            .catch(error => {
+                console.error('Failed to fetch GA version:', error);
+            });
+    
         message.loading({
             content: "Loading Data",
             duration: 0,
             style: {position: "fixed", left: "50%", top: "20%"}
         });
     }, []);
+    
 
     const handleLoaded = () => {
         message.destroy();
@@ -84,21 +94,22 @@ function RpmImages() {
                     </div>
 
                     <div className={"version-header"} style={{ display: 'flex', justifyContent: 'space-between', padding: '30px' }}>
-                        {selectedVersion && 
-                            <Title level={2} style={{ paddingLeft: '20px' }}>
-                                <code>
-                                    {selectedVersion === `openshift-${process.env.NEXT_PUBLIC_GA_VERSION}` ?
-                                        `${selectedVersion} (GA)`
-                                        :
-                                        selectedVersion
-                                    }
-                                </code>
-                            </Title>
-                        }
-                        <div align="right">
-                        <OPENSHIFT_VERSION_SELECT initialVersion={initialVersion} onVersionChange={setSelectedVersion} />
-                        </div>
+                    {selectedVersion && gaVersionValue && 
+                        <Title level={2} style={{ paddingLeft: '20px' }}>
+                            <code>
+                                {selectedVersion === `openshift-${gaVersionValue}` ?
+                                    `${selectedVersion} (GA)`
+                                    :
+                                    selectedVersion
+                                }
+                            </code>
+                        </Title>
+                    }
+                    <div align="right">
+                    <OPENSHIFT_VERSION_SELECT initialVersion={initialVersion} onVersionChange={setSelectedVersion} />
                     </div>
+                </div>
+
                     
                     <div style={selectedVersion ? { marginLeft: '20px' } : { display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
                         {selectedVersion 


### PR DESCRIPTION
Implemented the following changes:
- Enhanced OCP bugs integration into the release page while preserving the existing status and count display.
- Purged superfluous debugging logs from the codebase.
- Migrated to a dynamic GA version fetching mechanism with caching capabilities instead of relying on static environment variables.
- Refactored the API call methods for cleaner and more modular code.
- Updated the release and RPM image components to use the new GA fetching mechanism.