### PR TITLE
Update regex pattern for Bug Component validation

### DIFF
--- a/components/self-service/new-content-form.tsx
+++ b/components/self-service/new-content-form.tsx
@@ -105,7 +105,7 @@ export default function NewContentForm({ onSubmit, defaultValues }: { onSubmit?:
     <Box>
       <TextField fullWidth label="Bug Component" variant="outlined"
         required
-        {...register("bugComponent", { required: true, pattern: /^[\w-]+$/ })}
+        {...register("bugComponent", { required: true, pattern: /^[\w-\/\s]+$/ })}
         error={errors.bugComponent !== undefined}
         helperText="What is the Jira or Bugzilla component of your OpenShift component?" />
     </Box>

--- a/pages/self-service/new-content.tsx
+++ b/pages/self-service/new-content.tsx
@@ -15,7 +15,9 @@ export default function NewContent() {
         <title>Add ART definition for OCP component</title>
       </Head>
       <Container maxWidth="xl">
-        <Typography component="h1" variant="h5" sx={{ mt: 6 }}>[BETA] Request a new image or rpm to be managed by ART and released with OCP</Typography>
+        <Typography component="h1" variant="h5" sx={{ mt: 6 }}>
+          Request a new image or rpm to be managed by ART and released with OCP
+        </Typography>
         <Box sx={{ mt: 6 }}>
           <NewContentWizard />
         </Box>


### PR DESCRIPTION
Changed the regex pattern used for validating the Jira or Bugzilla component field in the NewContentForm. Removed BETA tag in the header.