### PR TITLE
[ART-8257] Implement NVR Display with Build ID Links and Optimize URL Param Management

### DIFF
--- a/components/build/build_history_table.js
+++ b/components/build/build_history_table.js
@@ -1,13 +1,13 @@
-import {CheckOutlined, CloseOutlined, InfoCircleOutlined} from "@ant-design/icons";
-import {Col, Empty, Pagination, Row, Table, Tooltip, Input, Select, Popover} from "antd";
-import React, {useState, useEffect} from "react";
+import { CheckOutlined, CloseOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { Col, Empty, Pagination, Row, Table, Tooltip, Input, Select, Popover, Switch } from "antd";
+import React, { useState, useEffect } from "react";
 
-const {Search} = Input;
-const {Option} = Select;
+const { Search } = Input;
+const { Option } = Select;
 
 export default function BUILD_HISTORY_TABLE(props) {
     const text = "Partial search enabled. For exact search, enclose within quotes."
-    const [buildNoInput, setBuildNoInput] = useState(props.buildNo);
+    const [nvrInput, setNvrInput] = useState(props.nvr);
     const [taskIdInput, setTaskIdInput] = useState(props.taskId);
     const [packageNameInput, setPackageNameInput] = useState(props.packageName);
     const [versionInput, setVersionInput] = useState(props.version);
@@ -22,36 +22,36 @@ export default function BUILD_HISTORY_TABLE(props) {
                 return (
                     <Row>
                         <Col span={24} className="left">
-                            Build
+                            NVR &nbsp;
+                            <Popover content={text}>
+                                <InfoCircleOutlined style={{ color: "#1677ff" }} />
+                            </Popover>
                         </Col>
                         <Col span={24}>
+                            <Switch
+                                checkedChildren="Stream Only"
+                                unCheckedChildren="All Builds"
+                                checked={props.streamOnly}
+                                onChange={props.onStreamToggle}
+                            />
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Build Id"} onSearch={() => props.onBuildNoChange(buildNoInput)} value={buildNoInput} onChange={(e) => setBuildNoInput(e.target.value)}/>
+                                <Search placeholder={"NVR"} onSearch={() => props.onNvrChange(nvrInput)} value={nvrInput} onChange={(e) => setNvrInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
                 )
             },
             align: "center",
-            dataIndex: "build_0_id",
-            key: "build_0_id",
-            render: (text, record) => {
-                if (record["build_0_id"]) {
-                    return (
-                        <div>
-                            <a href={process.env.NEXT_PUBLIC_BREW_BUILD_LINK + record["build_0_id"]}
-                               target="_blank" rel="noopener noreferrer">
-                                {record["build_0_id"]}
-                            </a>
-                        </div>
-                    )
-                } else {
-                    return (
-                        <div>
-                            Not Available
-                        </div>
-                    )
-                }
+            dataIndex: "build_0_nvr",
+            key: "build_0_nvr",
+            render: (nvr, record) => {
+                const buildId = record.build_0_id; // Get the build ID from the record
+                const url = `${process.env.NEXT_PUBLIC_BREW_BUILD_LINK}${buildId}`; // Construct the URL using the build ID
+                return (
+                  <a href={url} target="_blank" rel="noopener noreferrer">
+                    {nvr ? nvr : 'Not Available'}
+                  </a>
+                );
             }
         },
         {
@@ -62,9 +62,9 @@ export default function BUILD_HISTORY_TABLE(props) {
                             Status
                         </Col>
                         <Col span={24}>
-                            <Select style={{width: "100%"}} value={props.buildStatus} onChange={props.onBuildStatusChange }>
-                                <Option value="success"><Tooltip title={"Success"}><CheckOutlined style={{color: "#52c41a"}}/></Tooltip></Option>
-                                <Option value="failure"><Tooltip title={"Failure"}><CloseOutlined style={{color: "#f55d42"}}/></Tooltip></Option>
+                            <Select style={{ width: "100%" }} value={props.buildStatus} onChange={props.onBuildStatusChange}>
+                                <Option value="success"><Tooltip title={"Success"}><CheckOutlined style={{ color: "#52c41a" }} /></Tooltip></Option>
+                                <Option value="failure"><Tooltip title={"Failure"}><CloseOutlined style={{ color: "#f55d42" }} /></Tooltip></Option>
                                 <Option value="">Both</Option>
                             </Select>
                         </Col>
@@ -78,14 +78,14 @@ export default function BUILD_HISTORY_TABLE(props) {
                 if (record["brew_faultCode"] === 0) {
                     return (
                         <div>
-                            <CheckOutlined style={{color: "#52c41a"}}/>
+                            <CheckOutlined style={{ color: "#52c41a" }} />
                         </div>
                     )
                 } else {
                     return (
                         <div>
                             <Tooltip title={"Fault Code is " + record["brew_faultCode"]}>
-                                <CloseOutlined style={{color: "#f55d42"}}/>
+                                <CloseOutlined style={{ color: "#f55d42" }} />
                             </Tooltip>
                         </div>
                     )
@@ -101,7 +101,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Task Id"} onSearch={() => props.onTaskIdChange(taskIdInput)} value={taskIdInput} onChange={(e) => setTaskIdInput(e.target.value)}/>
+                                <Search placeholder={"Task Id"} onSearch={() => props.onTaskIdChange(taskIdInput)} value={taskIdInput} onChange={(e) => setTaskIdInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -114,7 +114,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                 return (
                     <div>
                         <a href={process.env.NEXT_PUBLIC_BREW_TASK_LINK + record["brew_task_id"]}
-                           target="_blank" rel="noopener noreferrer">{record["brew_task_id"]}</a>
+                            target="_blank" rel="noopener noreferrer">{record["brew_task_id"]}</a>
                     </div>
                 )
             }
@@ -126,12 +126,12 @@ export default function BUILD_HISTORY_TABLE(props) {
                         <Col span={24} className="left">
                             Package Name &nbsp;
                             <Popover content={text}>
-                                <InfoCircleOutlined style={{color: "#1677ff"}}/>
+                                <InfoCircleOutlined style={{ color: "#1677ff" }} />
                             </Popover>
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Package Name"} onSearch={() => props.onPackageNameChange(packageNameInput)} value={packageNameInput} onChange={(e) => setPackageNameInput(e.target.value)}/>
+                                <Search placeholder={"Package Name"} onSearch={() => props.onPackageNameChange(packageNameInput)} value={packageNameInput} onChange={(e) => setPackageNameInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -150,7 +150,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Version"} onSearch={() => props.onVersionChange(versionInput)} value={versionInput} onChange={(e) => setVersionInput(e.target.value)}/>
+                                <Search placeholder={"Version"} onSearch={() => props.onVersionChange(versionInput)} value={versionInput} onChange={(e) => setVersionInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -174,7 +174,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"CGIT Id"} onSearch={() => props.onCgitChange(cgitInput)} value={cgitInput} onChange={(e) => setCgitInput(e.target.value)}/>
+                                <Search placeholder={"CGIT Id"} onSearch={() => props.onCgitChange(cgitInput)} value={cgitInput} onChange={(e) => setCgitInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -201,7 +201,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Full Git SHA"} onSearch={() => props.onSourceCommitChange(sourceCommitInput)} value={sourceCommitInput} onChange={(e) => setSourceCommitInput(e.target.value)}/>
+                                <Search placeholder={"Full Git SHA"} onSearch={() => props.onSourceCommitChange(sourceCommitInput)} value={sourceCommitInput} onChange={(e) => setSourceCommitInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -214,7 +214,7 @@ export default function BUILD_HISTORY_TABLE(props) {
                 if (record["label_io_openshift_build_commit_url"] !== null)
                     return (
                         <a href={record["label_io_openshift_build_commit_url"]} target="_blank"
-                           rel="noopener noreferrer">{record["label_io_openshift_build_commit_id"].slice(0, 8)}</a>
+                            rel="noopener noreferrer">{record["label_io_openshift_build_commit_id"].slice(0, 8)}</a>
                     )
                 else
                     return (
@@ -229,12 +229,12 @@ export default function BUILD_HISTORY_TABLE(props) {
                         <Col span={24} className="left">
                             Jenkins Build &nbsp;
                             <Popover content={"Authorized only for ART members"}>
-                                <InfoCircleOutlined style={{color: "#1677ff"}}/>
+                                <InfoCircleOutlined style={{ color: "#1677ff" }} />
                             </Popover>
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Jenkins Build URL"} onSearch={() => props.onJenkinsBuildChange(jenkinsBuildInput)} value={jenkinsBuildInput} onChange={(e) => setJenkinsBuildInput(e.target.value)}/>
+                                <Search placeholder={"Jenkins Build URL"} onSearch={() => props.onJenkinsBuildChange(jenkinsBuildInput)} value={jenkinsBuildInput} onChange={(e) => setJenkinsBuildInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -246,7 +246,7 @@ export default function BUILD_HISTORY_TABLE(props) {
             render: (data) => {
                 return (
                     <a href={data} target="_blank"
-                       rel="noopener noreferrer">{data.split("/").at(-2)}</a>
+                        rel="noopener noreferrer">{data.split("/").at(-2)}</a>
                 )
 
             }
@@ -258,12 +258,12 @@ export default function BUILD_HISTORY_TABLE(props) {
                         <Col span={24} className="left">
                             Time &nbsp;
                             <Popover content={"Partial search not possible"}>
-                                <InfoCircleOutlined style={{color: "#1677ff"}}/>
+                                <InfoCircleOutlined style={{ color: "#1677ff" }} />
                             </Popover>
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"eg: 2022-08-01 | 18:52:36"} onSearch={() => props.onTimeChange(timeInput)} value={timeInput} onChange={(e) => setTimeInput(e.target.value)}/>
+                                <Search placeholder={"eg: 2022-08-01 | 18:52:36"} onSearch={() => props.onTimeChange(timeInput)} value={timeInput} onChange={(e) => setTimeInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -281,30 +281,30 @@ export default function BUILD_HISTORY_TABLE(props) {
     ]
 
     useEffect(() => {
-        setBuildNoInput(props.buildNo);
+        setNvrInput(props.nvr);
         setTaskIdInput(props.taskId);
-        setPackageNameInput(props.packageName)
-        setVersionInput(props.version)
-        setCgitInput(props.cgit)
-        setSourceCommitInput(props.sourceCommit)
-        setJenkinsBuildInput(props.jenkinsBuild)
-        setTimeInput(props.time)
-    }, [props.buildNo, props.taskId, props.packageName, props.version, props.cgit, props.sourceCommit, props.jenkinsBuild, props.time]);
+        setPackageNameInput(props.packageName);
+        setVersionInput(props.version);
+        setCgitInput(props.cgit);
+        setSourceCommitInput(props.sourceCommit);
+        setJenkinsBuildInput(props.jenkinsBuild);
+        setTimeInput(props.time);
+    }, [props.nvr, props.taskId, props.packageName, props.version, props.cgit, props.sourceCommit, props.jenkinsBuild, props.time]);
 
 
     return (
         props.data ?
-            <div style={{padding: "30px"}}>
+            <div style={{ padding: "30px" }}>
                 <div>
-                    <Table dataSource={props.data} columns={columns} pagination={false}/>
-                    <div align={"right"} style={{paddingTop: "10px"}}>
+                    <Table dataSource={props.data} columns={columns} pagination={false} />
+                    <div align={"right"} style={{ paddingTop: "10px" }}>
                         <Pagination onChange={props.onChange} total={props.totalCount} pageSize={15}
-                                    showSizeChanger={false}/>
+                            showSizeChanger={false} />
                     </div>
                 </div>
 
             </div>
             :
-            <Empty/>
+            <Empty />
     );
 }


### PR DESCRIPTION
This commit introduces significant updates to the ART Dashboard UI, focusing on the build history section. The changes include:

1. Introduction of NVR Display with Build ID Hyperlinks:
   - Replaced the previous 'build_0_id' display with 'build_0_nvr', enhancing the information presented to users. Each NVR entry now links to its corresponding build ID, providing direct access to detailed build information. This change offers a more intuitive and informative experience for users navigating build histories.

2. Optimized URL Parameter Management: 
   - Refined the handling of URL parameters in the `updateURLWithFilters` and `onVersionChange` functions. The updated logic ensures that empty or null parameters are efficiently filtered out, leading to cleaner URLs and more accurate state management. This improvement enhances the overall user interaction with the dashboard by ensuring consistent and relevant data display based on selected filters.

3. Stream Filter Toggle Feature: 
   - Implemented a toggle switch for filtering stream-specific builds. This addition allows users to switch views between all builds and stream-only builds, granting greater control and flexibility in data analysis and viewing preferences.

These updates collectively aim to elevate the user experience on the ART Dashboard, by providing clearer data visualization and improved navigational ease within the build history module.
