### PR TITLE
[ART-8102] Refactor Package Name to Distgit Name

### DIFF
--- a/components/build/build_history_table.js
+++ b/components/build/build_history_table.js
@@ -9,7 +9,7 @@ export default function BUILD_HISTORY_TABLE(props) {
     const text = "Partial search enabled. For exact search, enclose within quotes."
     const [nvrInput, setNvrInput] = useState(props.nvr);
     const [taskIdInput, setTaskIdInput] = useState(props.taskId);
-    const [packageNameInput, setPackageNameInput] = useState(props.packageName);
+    const [DistgitNameInput, setDistgitNameInput] = useState(props.DistgitName);
     const [versionInput, setVersionInput] = useState(props.version);
     const [cgitInput, setCgitInput] = useState(props.cgit);
     const [sourceCommitInput, setSourceCommitInput] = useState(props.sourceCommit);
@@ -48,9 +48,9 @@ export default function BUILD_HISTORY_TABLE(props) {
                 const buildId = record.build_0_id; // Get the build ID from the record
                 const url = `${process.env.NEXT_PUBLIC_BREW_BUILD_LINK}${buildId}`; // Construct the URL using the build ID
                 return (
-                  <a href={url} target="_blank" rel="noopener noreferrer">
-                    {nvr ? nvr : 'Not Available'}
-                  </a>
+                    <a href={url} target="_blank" rel="noopener noreferrer">
+                        {nvr ? nvr : 'Not Available'}
+                    </a>
                 );
             }
         },
@@ -124,14 +124,14 @@ export default function BUILD_HISTORY_TABLE(props) {
                 return (
                     <Row>
                         <Col span={24} className="left">
-                            Package Name &nbsp;
+                            Distgit Name &nbsp;
                             <Popover content={text}>
                                 <InfoCircleOutlined style={{ color: "#1677ff" }} />
                             </Popover>
                         </Col>
                         <Col span={24}>
                             <Tooltip title="Press Enter to apply the filter">
-                                <Search placeholder={"Package Name"} onSearch={() => props.onPackageNameChange(packageNameInput)} value={packageNameInput} onChange={(e) => setPackageNameInput(e.target.value)} />
+                                <Search placeholder={"Distgit Name"} onSearch={() => props.onDistgitNameChange(DistgitNameInput)} value={DistgitNameInput} onChange={(e) => setDistgitNameInput(e.target.value)} />
                             </Tooltip>
                         </Col>
                     </Row>
@@ -283,13 +283,13 @@ export default function BUILD_HISTORY_TABLE(props) {
     useEffect(() => {
         setNvrInput(props.nvr);
         setTaskIdInput(props.taskId);
-        setPackageNameInput(props.packageName);
+        setDistgitNameInput(props.DistgitName);
         setVersionInput(props.version);
         setCgitInput(props.cgit);
         setSourceCommitInput(props.sourceCommit);
         setJenkinsBuildInput(props.jenkinsBuild);
         setTimeInput(props.time);
-    }, [props.nvr, props.taskId, props.packageName, props.version, props.cgit, props.sourceCommit, props.jenkinsBuild, props.time]);
+    }, [props.nvr, props.taskId, props.DistgitName, props.version, props.cgit, props.sourceCommit, props.jenkinsBuild, props.time]);
 
 
     return (

--- a/pages/dashboard/build/history/index.js
+++ b/pages/dashboard/build/history/index.js
@@ -1,17 +1,17 @@
-import React, {useEffect, useState, useCallback} from "react";
-import {getBuilds} from "../../../../components/api_calls/build_calls";
+import React, { useEffect, useState, useCallback } from "react";
+import { getBuilds } from "../../../../components/api_calls/build_calls";
 import BUILD_HISTORY_TABLE from "../../../../components/build/build_history_table";
-import {RocketOutlined, ReloadOutlined, FileImageOutlined} from "@ant-design/icons";
+import { RocketOutlined, ReloadOutlined, FileImageOutlined } from "@ant-design/icons";
 import Head from "next/head";
-import {Layout, Menu} from "antd";
-import {useRouter} from 'next/router';
+import { Layout, Menu } from "antd";
+import { useRouter } from 'next/router';
 
 export default function BUILD_HISTORY_HOME() {
     const [data, setData] = useState([]);
     const [searchParams, setSearchParams] = useState({})
     const [page, setPage] = useState(1);
     const [nvr, setNvr] = useState(""); // Updated from buildNo to nvr
-    const [packageName, setPackageName] = useState("");
+    const [DistgitName, setDistgitName] = useState("");
     const [buildStatus, setBuildStatus] = useState("");
     const [taskId, setTaskId] = useState("");
     const [version, setVersion] = useState("");
@@ -23,7 +23,7 @@ export default function BUILD_HISTORY_HOME() {
     const router = useRouter();
     const [streamOnly, setStreamOnly] = useState(false);
 
-    const {Footer, Sider} = Layout;
+    const { Footer, Sider } = Layout;
 
     const onPageChange = (pageNo) => {
         setPage(pageNo);
@@ -34,19 +34,19 @@ export default function BUILD_HISTORY_HOME() {
     const updateURLWithFilters = useCallback((updatedParams) => {
         // Merge the current searchParams with the new parameters
         const mergedParams = { ...searchParams, ...updatedParams };
-    
+
         // Filter out empty or null parameters
         Object.keys(mergedParams).forEach(key => {
             if (mergedParams[key] === "" || mergedParams[key] == null) {
                 delete mergedParams[key];
             }
         });
-    
+
         // Construct the new URL with the filtered parameters
         const newURL = new URL(window.location.href);
         newURL.search = new URLSearchParams(mergedParams).toString();
         window.history.pushState({}, '', newURL.toString());
-    
+
         // Update the searchParams state
         setSearchParams(mergedParams);
     }, [searchParams]);
@@ -56,8 +56,8 @@ export default function BUILD_HISTORY_HOME() {
         updateURLWithFilters({ build_0_nvr: nvrValue.trim() }); // Updated to use build_0_nvr
     }, [updateURLWithFilters]);
 
-    const onPackageNameChange = useCallback((name) => {
-        setPackageName(name.trim());
+    const onDistgitNameChange = useCallback((name) => {
+        setDistgitName(name.trim());
         updateURLWithFilters({ dg_name: name.trim() });
     }, [updateURLWithFilters]);
 
@@ -74,18 +74,18 @@ export default function BUILD_HISTORY_HOME() {
     const onVersionChange = (ver) => {
         const trimmedVer = ver.trim();
         let updatedParams = { ...searchParams };
-        
+
         if (trimmedVer) {
             updatedParams.group = `openshift-${trimmedVer}`;
         } else {
             delete updatedParams.group; // Remove 'group' key if version is cleared
         }
-    
+
         // Update the URL
         const newURL = new URL(window.location.href);
         newURL.search = new URLSearchParams(updatedParams).toString();
         window.history.pushState({}, '', newURL.toString());
-    
+
         // Now update the state
         setSearchParams(updatedParams);
         setVersion(trimmedVer);
@@ -126,7 +126,7 @@ export default function BUILD_HISTORY_HOME() {
         const loadedParams = Object.fromEntries(params.entries());
 
         setNvr(loadedParams["build_0_nvr"] || "");
-        setPackageName(loadedParams["dg_name"] || "");
+        setDistgitName(loadedParams["dg_name"] || "");
         setBuildStatus(loadedParams["brew_task_state"] || "");
         setTaskId(loadedParams["brew_task_id"] || "");
         setVersion(loadedParams["group"] ? loadedParams["group"].replace('openshift-', '') : "");
@@ -141,7 +141,7 @@ export default function BUILD_HISTORY_HOME() {
 
     useEffect(() => {
         let isMounted = true;
-    
+
         const getData = () => {
             getBuilds(searchParams, streamOnly).then((fetchedData) => {
                 if (isMounted && fetchedData && Array.isArray(fetchedData["results"])) {
@@ -150,15 +150,15 @@ export default function BUILD_HISTORY_HOME() {
                 }
             });
         };
-    
+
         getData();
-    
+
         return () => {
             isMounted = false;
         };
     }, [searchParams, streamOnly]);
 
-    
+
     const handleStreamToggle = (checked) => {
         setStreamOnly(checked);
     };
@@ -166,18 +166,18 @@ export default function BUILD_HISTORY_HOME() {
     const menuItems = [
         {
             key: "releaseStatusMenuItem",
-            icon: <RocketOutlined/>,
-            label: <a href={"/dashboard"}><p style={{fontSize: "medium"}}>Release status</p></a>
+            icon: <RocketOutlined />,
+            label: <a href={"/dashboard"}><p style={{ fontSize: "medium" }}>Release status</p></a>
         },
         {
             key: "buildHistory",
-            icon: <ReloadOutlined/>,
-            label: <a href={"/dashboard/build/history"}><p style={{fontSize: "medium"}}>Build History</p></a>
+            icon: <ReloadOutlined />,
+            label: <a href={"/dashboard/build/history"}><p style={{ fontSize: "medium" }}>Build History</p></a>
         },
         {
             key: "rpmImages",
-            icon: <FileImageOutlined/>,
-            label: <a href={"/dashboard/rpm_images"}><p style={{fontSize: "medium"}}>RPMs & Images</p></a>
+            icon: <FileImageOutlined />,
+            label: <a href={"/dashboard/rpm_images"}><p style={{ fontSize: "medium" }}>RPMs & Images</p></a>
         }
     ]
 
@@ -186,12 +186,12 @@ export default function BUILD_HISTORY_HOME() {
         <div>
             <Head>
                 <title>ART Dashboard</title>
-                <link rel="icon" href="/redhat-logo.png"/>
+                <link rel="icon" href="/redhat-logo.png" />
             </Head>
             <Layout>
                 <Sider collapsed={false}>
-                    <div style={{paddingTop: "10px"}}>
-                        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']} items={menuItems}/>
+                    <div style={{ paddingTop: "10px" }}>
+                        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']} items={menuItems} />
 
                     </div>
                 </Sider>
@@ -211,16 +211,16 @@ export default function BUILD_HISTORY_HOME() {
                                 Portal</h1>
                         </div>
                     </div>
-                    <BUILD_HISTORY_TABLE data={data} nvr={nvr} buildStatus={buildStatus} taskId={taskId} packageName={packageName} 
-                                         version={version} cgit={cgit} sourceCommit={sourceCommit} jenkinsBuild={jenkinsBuild} 
-                                         time={time} totalCount={totalCount} streamOnly={streamOnly} 
-                                         onChange={onPageChange} onNvrChange={onNvrChange}
-                                         onPackageNameChange={onPackageNameChange} onBuildStatusChange={onBuildStatusChange}
-                                         onTaskIdChange={onTaskIdChange} onVersionChange={onVersionChange}
-                                         onCgitChange={onCgitChange} onSourceCommitChange={onSourceCommitChange}
-                                         onTimeChange={onTimeChange} onJenkinsBuildChange={onJenkinsBuildChange}
-                                         onStreamToggle={handleStreamToggle} />
-                    <Footer style={{textAlign: 'center'}}>
+                    <BUILD_HISTORY_TABLE data={data} nvr={nvr} buildStatus={buildStatus} taskId={taskId} DistgitName={DistgitName}
+                        version={version} cgit={cgit} sourceCommit={sourceCommit} jenkinsBuild={jenkinsBuild}
+                        time={time} totalCount={totalCount} streamOnly={streamOnly}
+                        onChange={onPageChange} onNvrChange={onNvrChange}
+                        onDistgitNameChange={onDistgitNameChange} onBuildStatusChange={onBuildStatusChange}
+                        onTaskIdChange={onTaskIdChange} onVersionChange={onVersionChange}
+                        onCgitChange={onCgitChange} onSourceCommitChange={onSourceCommitChange}
+                        onTimeChange={onTimeChange} onJenkinsBuildChange={onJenkinsBuildChange}
+                        onStreamToggle={handleStreamToggle} />
+                    <Footer style={{ textAlign: 'center' }}>
                         RedHat © 2023
                     </Footer>
                 </Layout>


### PR DESCRIPTION
Updated state and function names from packageName to DistgitName to better reflect the data being handled. Changes include:

- Renamed state variable 'packageNameInput' to 'DistgitNameInput'.
- Updated placeholders and tooltips from 'Package Name' to 'Distgit Name'.
- Adjusted useEffect dependencies to use 'DistgitName' instead of 'packageName'.
- Modified BUILD_HISTORY_HOME component to use 'DistgitName' for handling distgit name changes.

These changes enhance code clarity and align the variable names with their actual usage in the ART Dashboard UI.