### PR TITLE
ART-10508: add Jira and PR creation logic with submitRequest button

### DIFF
--- a/components/api_calls/api_calls.js
+++ b/components/api_calls/api_calls.js
@@ -7,7 +7,7 @@ axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 let server_endpoint = null;
 
 if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
-    server_endpoint = "http://localhost:8080";
+    server_endpoint = "http://chopin2:8080";
 } else {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE;
 }

--- a/components/api_calls/api_calls.js
+++ b/components/api_calls/api_calls.js
@@ -7,7 +7,7 @@ axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 let server_endpoint = null;
 
 if (process.env.NEXT_PUBLIC_RUN_ENV === "dev") {
-    server_endpoint = "http://chopin2:8080";
+    server_endpoint = "http://localhost:8080";
 } else {
     server_endpoint = process.env.NEXT_PUBLIC_ART_DASH_SERVER_ROUTE;
 }

--- a/components/api_calls/api_calls.js
+++ b/components/api_calls/api_calls.js
@@ -56,7 +56,17 @@ function makeApiCall(urlPath, method, data = {}, headers = {}, params = {}, req 
     })
     .catch(error => {
         console.error("API call failed:", error);
-        return { detail: 'Request failed' };
+
+        // If an error occurred, attempt to strigify the response data and
+        // include it in the error message so that it can be displayed in the UI.
+        let errorDetails = error.message;
+        try {
+            const errorResponseData = JSON.stringify(error.response?.data);
+            errorDetails += `, ${errorResponseData}`;
+        } catch (error) {
+            console.error("Error parsing response data:", error);
+        }
+        return { detail: 'Request failed', 'message': `${errorDetails}` };
     });
 }
 

--- a/components/release/openshift_version_select.js
+++ b/components/release/openshift_version_select.js
@@ -4,7 +4,7 @@ import {getReleaseBranchesFromOcpBuildData} from "../api_calls/release_calls";
 
 const {Option} = Select;
 
-function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='right', padding='30px', redirectOnSelect=false, useDefaultValue=true}) {
+function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='right', padding='30px', redirectOnSelect=false, useDefaultValue=true }) {
     const [data, setData] = useState([]);
 
     const setDataFunc = () => {

--- a/components/release/openshift_version_select.js
+++ b/components/release/openshift_version_select.js
@@ -4,7 +4,7 @@ import {getReleaseBranchesFromOcpBuildData} from "../api_calls/release_calls";
 
 const {Option} = Select;
 
-function OpenshiftVersionSelect({ onVersionChange, initialVersion, redirectOnSelect=false }) {
+function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='right', padding='30px', redirectOnSelect=false }) {
     const [data, setData] = useState([]);
 
     const setDataFunc = () => {
@@ -47,7 +47,7 @@ function OpenshiftVersionSelect({ onVersionChange, initialVersion, redirectOnSel
 
     // Simplify the render function by removing the if-else
     return (
-        <div align={"right"} style={{padding: "30px"}}>
+        <div align={alignment} style={{padding: {padding}}}>
             <Select defaultValue={initialVersion} placeholder={<div style={{color: "black"}}>Openshift Version</div>} onChange={onChangeFunc}>
                 {generateSelectOptionFromStateDate(data)}
             </Select>

--- a/components/release/openshift_version_select.js
+++ b/components/release/openshift_version_select.js
@@ -4,7 +4,7 @@ import {getReleaseBranchesFromOcpBuildData} from "../api_calls/release_calls";
 
 const {Option} = Select;
 
-function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='right', padding='30px', redirectOnSelect=false }) {
+function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='right', padding='30px', redirectOnSelect=false, useDefaultValue=true}) {
     const [data, setData] = useState([]);
 
     const setDataFunc = () => {
@@ -47,8 +47,11 @@ function OpenshiftVersionSelect({ onVersionChange, initialVersion, alignment='ri
 
     // Simplify the render function by removing the if-else
     return (
-        <div align={alignment} style={{padding: {padding}}}>
-            <Select defaultValue={initialVersion} placeholder={<div style={{color: "black"}}>Openshift Version</div>} onChange={onChangeFunc}>
+        <div align={alignment} style={{ padding: { padding } }}>
+            <Select
+                {...(useDefaultValue ? { defaultValue: initialVersion } : { value: initialVersion })}
+                placeholder={<div style={{ color: "black" }}>Openshift Version</div>} onChange={onChangeFunc}
+            >
                 {generateSelectOptionFromStateDate(data)}
             </Select>
         </div>

--- a/components/self-service/new-content-done.tsx
+++ b/components/self-service/new-content-done.tsx
@@ -189,13 +189,15 @@ export default function NewContentDone() {
       });
       const response = await makeApiCall('/api/v1/git_jira_api', 'GET', {}, {}, params, false);
       setDialogTitle('Error occurred');
-      if (response.status === "success") {
+      if (response?.status === "success") {
         // Override the dialog title and content to show Jira and PR URLs.
         setDialogTitle('Jira and PR created successfully:');
         setDialogContent([response.jira_url, response.pr_url]);
       } else {
-        setDialogContent([`ART UI server return status: ${response.status}`, `Error message: ${response.error}`]);
-
+        setDialogContent([`ART UI server return status: ${response?.status}`,
+                          `Error message: ${response?.error}`,
+                          `Other error: ${response?.detail}`,
+                          `Other message: ${response?.message}`]);
         // If the call to ART UI server failed, we should allow the user to try again.
         setIsSubmitted(false);
       }

--- a/components/self-service/new-content-done.tsx
+++ b/components/self-service/new-content-done.tsx
@@ -138,31 +138,31 @@ export default function NewContentDone() {
     const priority = "Normal";
 
     const fileContent = `content:
-    source:
-      dockerfile: Dockerfile.openshift
-      git:
-        branch:
-          target: release-{MAJOR}.{MINOR}
-        url: ${repo_url}
-        web: ${web_url}
-      ci_alignment:
-        streams_prs:
-          ci_build_root:
-            stream: rhel-9-golang-ci-build-root
-  distgit:
-    branch: rhaos-{MAJOR}.{MINOR}-rhel-9
-    component: ${imageName}-container
-  enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
-  for_payload: false
-  from:
-    builder:
-    - stream: rhel-9-golang
-    member: openshift-enterprise-base-rhel9
-  name: openshift/${imageName}-rhel9
-  owners:
-  - ${inputs.deliveryRepoImageOwner}@redhat.com
+  source:
+    dockerfile: Dockerfile.openshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: ${repo_url}
+      web: ${web_url}
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ${imageName}-container
+enabled_repos:
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
+for_payload: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/${imageName}-rhel9
+owners:
+- ${inputs.deliveryRepoImageOwner}@redhat.com
 `;
 
     const params = {

--- a/components/self-service/new-content-form.tsx
+++ b/components/self-service/new-content-form.tsx
@@ -18,7 +18,7 @@ import { Inputs, useNewContentState } from './new-content-state'
 import HelpIcon from '@mui/icons-material/Help';
 import frontendConfig from "../../frontend.config.json"
 import { useState } from 'react';
-
+import OpenshiftVersionSelect from "../release/openshift_version_select";
 
 const applicationCategories = [
   'API Management',
@@ -116,7 +116,12 @@ export default function NewContentForm({ onSubmit, defaultValues }: { onSubmit?:
       setValue("deliveryRepoApplicationCategories", new Set(newCategories));
       setSelectedAppCategories(newCategories);
     }
-};
+  };
+
+  const [userImageReleaseVersion, setUserImageReleaseVersion] = useState('openshift-4.17')
+  const handleImageReleaseChange = (version: string) => {
+    setUserImageReleaseVersion(version);
+  }
 
   const values = watch();
 
@@ -129,6 +134,25 @@ export default function NewContentForm({ onSubmit, defaultValues }: { onSubmit?:
     }}
   >
     <Typography component="h1" variant="h5" sx={{ my: 2 }}>General</Typography>
+    <Box>
+      <FormLabel id="openshift-image-version">Onboard image to this OpenShift Version</FormLabel>
+      <Controller
+        control={control}
+        name="imageReleaseVersion"
+        defaultValue={userImageReleaseVersion}
+        render={({ field: { onChange, value } }) => (
+          <OpenshiftVersionSelect
+            initialVersion={value}
+            alignment='left'
+            padding='0px'
+            onVersionChange={(version) => {
+              onChange(version);
+              setUserImageReleaseVersion(version);
+            }}
+          />
+        )}
+      />
+    </Box>
     <Box>
       <FormControl>
         <FormLabel id="component-type-group-label">Component Type</FormLabel>

--- a/components/self-service/new-content-form.tsx
+++ b/components/self-service/new-content-form.tsx
@@ -80,6 +80,9 @@ export default function NewContentForm({ onSubmit, defaultValues }: { onSubmit?:
     defaultValues: inputs,
   });
   const onSubmitHandler: SubmitHandler<Inputs> = data => {
+    // Because the image release version is determined dynamically and stored in a variable
+    // separate from the form, we need to update the data before updating the inputs.
+    data.imageReleaseVersion = userImageReleaseVersion
     console.log("data=", data);
     setInputs(data);
     if (onSubmit) {

--- a/components/self-service/new-content-form.tsx
+++ b/components/self-service/new-content-form.tsx
@@ -551,7 +551,7 @@ export default function NewContentForm({ onSubmit, defaultValues }: { onSubmit?:
       </Box>
       <Box>
         <TextField label="Errata Writer" variant="outlined" fullWidth
-                   {...register("deliveryRepoErrataWriter", { required: true})}
+                   {...register("deliveryRepoErrataWriter", { required: false})}
                    helperText="[OPTIONAL] If different from Documentation Writer. Email(s) of Customer Content Services contact(s) responsible for writing Errata text for this repository. Can be comma separated." />
       </Box>
 

--- a/components/self-service/new-content-state.tsx
+++ b/components/self-service/new-content-state.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, ReactNode, useMemo, useReducer, useCallback } from "react";
 
 export type Inputs = {
+  imageReleaseVersion?: string,
   componentType?: string,
   distgit?: string,
   productManager?: string,

--- a/components/self-service/new-content-wizard.tsx
+++ b/components/self-service/new-content-wizard.tsx
@@ -20,7 +20,7 @@ export function NewContentStep({ activeStep }: { activeStep: number }) {
       return (
         <Box sx={{ m: 4 }}>
           <Typography component="h1" variant="h4" sx={{ my: 2 }}>Step 2: Fill the onboarding form</Typography>
-          <NewContentForm onSubmit={(data: any) => console.log(data)} />
+          <NewContentForm onSubmit={(data: any) => console.log('Fill onboarding form: ', data)} />
         </Box>)
     case 2:
       return (


### PR DESCRIPTION
This calls the new /git_jira_api endpoint introduced in [this PR](https://github.com/openshift-eng/art-dashboard-server/pull/150) in the art-ui-server backend to create the PR and Jira for image add requests.

That PR must merge first.

