### PR TITLE
Change the URL of Beta Build History

### DIFF
--- a/.env
+++ b/.env
@@ -32,4 +32,4 @@ NEXT_PUBLIC_RUN_ENV=prod
 # art-dash server API endpoint
 NEXT_PUBLIC_API_ENDPOINT=api/v1
 
-NEXT_PUBLIC_BETA_BUILD_HISTORY_LINK = https://konflux-build-history-hackspace-dpaolell.apps.artc2023.pc3z.p1.openshiftapps.com/
+NEXT_PUBLIC_BETA_BUILD_HISTORY_LINK = https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com


### PR DESCRIPTION
Change the URL that `Build History: Beta` points to to https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com