### PR TITLE
ART-11178: Pass in values to support making jira subtasks

### DIFF
--- a/components/self-service/new-content-done.tsx
+++ b/components/self-service/new-content-done.tsx
@@ -175,6 +175,8 @@ owners:
       jira_story_type_id: ARTStoryTypeID,
       jira_component: component,
       jira_priority: priority,
+      image_type: inputs.imageType,
+      payload_name: inputs.payloadName,
 
       // the default mode is test mode (i.e., create fake PR and Jira) so you can easily
       // test the UI and API and be intentional about actually creating the PR and Jira.


### PR DESCRIPTION
These changes pass the imageType, payloadName to the [ART UI backend](https://github.com/openshift-eng/art-dashboard-server/pull/158) so it will know what subtasks to add to the automatically generated Jira.

This PR can merge anytime because without https://github.com/openshift-eng/art-dashboard-server/pull/158, these values are ignored.

This [Jira](https://issues.redhat.com/browse/ART-11803) is what this code produced (for the payload case).