### PR TITLE
strip leading and trailing whitespaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ class KonfluxBuildHistory(Flask):
         else:
             where_clauses['outcome'] = params['outcome']
 
+        params['name'] = params['name'].strip()
         extra_patterns = {}
         if params['name']:
             extra_patterns['name'] = params['name']


### PR DESCRIPTION
Its hard to see if we accidentally included any leading/trailing whitespaces.