### PR TITLE
ART-12168: fixed variables coming from onboarding form

### DIFF
--- a/components/self-service/new-content-done.tsx
+++ b/components/self-service/new-content-done.tsx
@@ -139,7 +139,7 @@ export default function NewContentDone() {
 
     const fileContent = `content:
   source:
-    dockerfile: Dockerfile.openshift
+    dockerfile: ${inputs.dockerfilePath}
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -155,7 +155,7 @@ distgit:
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
-for_payload: false
+for_payload: ${inputs.imageType === "cvo-payload" || inputs.hasOperatorLabel}
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
tested locally art-dashboard-ui:
1. go to my cloned art-dashboard-ui
2. run npm install (you need the node package for this)
3. Run npx next dev
4. Go to localhost:3000 in my browser
5. Fill the form: http://localhost:3000/self-service/new-content
6. when doing the final step (submit) I get this payload:
```
image_name: foo
release_for_image: openshift-4.20
file_content: content:
  source:
    dockerfile: /path_1/Dockerfile.mbiarnes
    git:
      branch:
        target: release-{MAJOR}.{MINOR}
      url: git@github.com:openshift-priv/foo.git
      web: https://github.com/openshift/foo
    ci_alignment:
      streams_prs:
        ci_build_root:
          stream: rhel-9-golang-ci-build-root
distgit:
  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
  component: foo-container
enabled_repos:
- rhel-9-appstream-rpms
- rhel-9-baseos-rpms
for_payload: true
from:
  builder:
  - stream: rhel-9-golang
  member: openshift-enterprise-base-rhel9
name: openshift/foo-rhel9
owners:
- mbiarnes@redhat.com@redhat.com
```

for_payload and dockerfile are OK