### PR TITLE
Improve UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -180,10 +180,21 @@ td.nvr-td {
 
 th {
     background-color: #333;
+    min-width: 100px;
 }
 
 td {
     background-color: #2b2b2b;
+}
+
+td ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+td ul li {
+    padding: 7px;
 }
 
 select {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ART build history</title>
 
+    <!-- Include Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+
     <!-- Favicon for the browser tab -->
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='history.png') }}">
 
@@ -96,9 +99,7 @@
                         <th>Time</th>
                         <th>Engine</th>
                         <th>Packages</th>
-                        <th>Source URL</th>
-                        <th>Pipeline URL</th>
-                        <th>ART job URL</th>
+                        <th>Links</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
- Display the build age in a descriptive form (e.g. `"2 weeks ago"`)
- Auto-select the most recent group in the search options
- Group build links (commit URL, build pipeline URL, ART job URL) under the same cell to keep the table compact