### PR TITLE
ART-13365: add art-images-share-pullspec

### DIFF
--- a/app.py
+++ b/app.py
@@ -132,6 +132,8 @@ class KonfluxBuildHistory(Flask):
                         'Failed fetching information for build %s with state %s: %s', nvr, outcome, e)
                     result = default_result
 
+            result["art_images_share_pullspec"] = result["image_pullspec"].replace("art-images", "art-images-share")
+
             return render_template("build.html",
                                    nvr=nvr,
                                    build=result)


### PR DESCRIPTION
Adding a new field `art_images_share_pullspec` to display on the build history page. Since we are pushing the same digest, only the URL will be different.

```
quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:bc57230cebe3fdb2333a08c14137d1fa998b409be5c4135106604a9c8c646757
```
 to

```
quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share@sha256:bc57230cebe3fdb2333a08c14137d1fa998b409be5c4135106604a9c8c646757
```