### PR TITLE
Deprecate @release-artists handle

### DIFF
--- a/components/self-service/new-content-checklist.tsx
+++ b/components/self-service/new-content-checklist.tsx
@@ -38,7 +38,7 @@ export function NewContentChecklist() {
       <FormControlLabel control={<Checkbox {...register("check_operator_hub", {required: true})} />}
                         label="Is this an Operator destined for Operator Hub? Talk to ART before proceeding."/>
       <Tooltip title={`OperatorHub, aka Marketplace, App Registry, and various other names - you are shipping your operator
-                  through the marketplace/OperatorHub if it is not one of the operators deployed by the CVO (cluster version operator) but instead by OLM. Reach out to @release-artists on #forum-ocp-art`}>
+                  through the marketplace/OperatorHub if it is not one of the operators deployed by the CVO (cluster version operator) but instead by OLM. Reach out to @automated-tooling-triage on #forum-ocp-art`}>
         <IconButton color="primary" aria-label="help" href={configData.cpaas_doc_help_link} target="_blank">
           <HelpIcon/>
         </IconButton>

--- a/components/self-service/new-content-done.tsx
+++ b/components/self-service/new-content-done.tsx
@@ -246,7 +246,7 @@ owners:
       </Typography>
       <ul>
         <li>If the above looks good, click the Submit Request button and a Jira and PR will be created</li>
-        <li>Inform <strong>@release-artists</strong> on <strong>#forum-ocp-art</strong> on Slack about the Jira and PR</li>
+        <li>Inform <strong>@automated-tooling-triage</strong> on <strong>#forum-ocp-art</strong> on Slack about the Jira and PR</li>
       </ul>
     </Box>
     <Box sx={{ py: 2 }}>


### PR DESCRIPTION
## Summary
- Replace all `@release-artists` references with `@automated-tooling-triage` in self-service UI components

## Files Changed
- `components/self-service/new-content-checklist.tsx` (1 occurrence)
- `components/self-service/new-content-done.tsx` (1 occurrence)

## Test plan
- [ ] Verify no remaining references to `release-artists` in changed files

Made with [Cursor](https://cursor.com)