### PR TITLE
Fix server startup crash and brittle /dashboard redirect

### DIFF
--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -33,24 +33,23 @@ function user_details_for_user_id(user_id) {
 function gaVersion() {
     const currentTime = new Date().getTime();  // Moved the definition up
 
-    if (typeof localStorage !== 'undefined') {
+    if (typeof window !== 'undefined' && window.localStorage) {
         const cachedGaVersion = localStorage.getItem('gaVersion');
         const cachedTimestamp = localStorage.getItem('gaVersionTimestamp');
-        
+
         const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
 
         // If cached version exists and it's not older than a day
         if (cachedGaVersion && cachedTimestamp && (currentTime - cachedTimestamp < oneDayInMilliseconds)) {
             return Promise.resolve({ payload: cachedGaVersion });
-        } 
+        }
     }
     
     // If localStorage is not available or cached data is stale
     const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/ga-version`;
     return makeApiCall(url, 'GET', headers)
         .then(response => {
-            if (typeof localStorage !== 'undefined') {
-                // Save the new value and timestamp to local storage
+            if (typeof window !== 'undefined' && window.localStorage) {
                 localStorage.setItem('gaVersion', response.payload);
                 localStorage.setItem('gaVersionTimestamp', currentTime.toString());
             }

--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,25 @@
 const { gaVersion } = require('./components/api_calls/release_calls');
+
+const FALLBACK_GA_VERSION = '4.21';
+
 module.exports = {
     transpilePackages: ["antd", "@ant-design", "rc-util", "rc-pagination", "rc-picker", "rc-notification", "rc-tooltip", "rc-tree", "rc-table"],
     async redirects() {
-        const gaResponse = await gaVersion();
-        const currentGaVersion = gaResponse.payload;
+        let currentGaVersion = FALLBACK_GA_VERSION;
+        try {
+            const gaResponse = await gaVersion();
+            if (gaResponse && gaResponse.payload) {
+                currentGaVersion = gaResponse.payload;
+            }
+        } catch (e) {
+            console.error('[next.config.js] gaVersion failed, using fallback:', e.message);
+        }
 
-        // Set redirect automatically to GA release version page
         return [
             {
                 source: '/dashboard',
                 destination: `/dashboard/release/openshift-${currentGaVersion}`,
-                permanent: true,
+                permanent: false,
             },
         ];
     }


### PR DESCRIPTION
## Summary

- **Fix TypeError crash on startup**: `gaVersion()` in `release_calls.js` used `typeof localStorage !== 'undefined'` to guard browser-only code. In Node.js (where `next.config.js` runs), this guard evaluates to `true` but `localStorage.getItem` is not a function, crashing the server on every pod restart. Fixed to `typeof window !== 'undefined' && window.localStorage`.

- **Add error handling for the `/dashboard` redirect**: The redirect destination was computed with no error handling — if the `ga-version` backend call failed for any reason, the destination became `/dashboard/release/openshift-undefined`. Added try/catch with a hardcoded fallback (`4.21`) so startup succeeds and the redirect still lands on a valid page.

- **Change 301 → 302 for `/dashboard` redirect**: A permanent redirect is cached forever by browsers. Since the GA version changes with each OCP release, users would be stuck on an old version until they manually cleared their cache. A temporary (302) redirect forces browsers to check the server each time.

## Test plan

- [ ] Restart the server and confirm `/dashboard` redirects to the current GA version
- [ ] Verify no `TypeError: localStorage.getItem is not a function` in server logs on startup
- [ ] Simulate a backend failure during startup and confirm the server still starts and `/dashboard` redirects to the fallback version

🤖 Generated with [Claude Code](https://claude.com/claude-code)