### PR TITLE
Add tsconfig.json and fix skeleton shimmer visibility

### DIFF
--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -6,10 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn(
-        "rounded-md bg-muted animate-shimmer bg-[length:200%_100%] bg-gradient-to-r from-muted via-muted-foreground/5 to-muted",
-        className
-      )}
+      className={cn("skeleton-shimmer rounded-md", className)}
       {...props}
     />
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,3 +50,20 @@
     -moz-osx-font-smoothing: grayscale;
   }
 }
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton-shimmer {
+  background: linear-gradient(90deg, #d4d4d8 25%, #e4e4e7 50%, #d4d4d8 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.dark .skeleton-shimmer {
+  background: linear-gradient(90deg, #27272a 25%, #3f3f46 50%, #27272a 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add missing tsconfig.json required for TypeScript compilation (Docker build was failing without it)
- Fix skeleton loading bars barely visible in light mode — now uses explicit gradient colors with CSS keyframe animation
- Verified with Docker build and deploy on port 8080

## Test plan
- [ ] Run Docker build: docker build -t art-dashboard-ui:test .
- [ ] Verify skeleton shimmer is visible in both light and dark mode
- [ ] Verify all pages still load correctly

Generated with [Claude Code](https://claude.com/claude-code)