### PR TITLE
Add structured table skeleton and progressive row animation

### DIFF
--- a/components/dashboard/AdvisoryTable.tsx
+++ b/components/dashboard/AdvisoryTable.tsx
@@ -35,15 +35,74 @@ interface AdvisoryTableProps {
   loading?: boolean;
 }
 
+const SKELETON_ROWS = 5;
+
+const SKELETON_WIDTHS = [
+  ["w-16", "w-14", "w-20", "w-12", "w-24", "w-20", "w-24", "w-20", "w-24", "w-16"],
+  ["w-10", "w-14", "w-16", "w-14", "w-24", "w-24", "w-28", "w-24", "w-28", "w-20"],
+  ["w-14", "w-14", "w-14", "w-16", "w-24", "w-16", "w-20", "w-16", "w-20", "w-24"],
+  ["w-20", "w-14", "w-20", "w-10", "w-24", "w-20", "w-28", "w-20", "w-28", "w-12"],
+  ["w-16", "w-14", "w-12", "w-14", "w-24", "w-16", "w-24", "w-16", "w-24", "w-16"],
+];
+
 function TableSkeleton() {
   return (
-    <div className="space-y-2 p-4">
-      {[...Array(5)].map((_, i) => (
-        <Skeleton key={i} className="h-10 w-full" />
-      ))}
-    </div>
+    <Table>
+      <TableHeader>
+        <TableRow className="border-b border-border hover:bg-transparent">
+          <TableHead className="border-r border-border">Advisory</TableHead>
+          <TableHead colSpan={4} className="border-r border-border text-center">
+            Advisory Details
+          </TableHead>
+          <TableHead colSpan={2} className="border-r border-border text-center">
+            Doc
+          </TableHead>
+          <TableHead colSpan={2} className="border-r border-border text-center">
+            Product Security
+          </TableHead>
+          <TableHead className="text-center">Bugs</TableHead>
+        </TableRow>
+        <TableRow className="border-b border-border bg-card hover:bg-transparent dark:bg-zinc-950/50">
+          <TableHead className="border-r border-border">Type</TableHead>
+          <TableHead className="border-r border-border/50">Errata ID</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="border-r border-border">Release Date</TableHead>
+          <TableHead>Approval</TableHead>
+          <TableHead className="border-r border-border">Reviewer</TableHead>
+          <TableHead>Approval</TableHead>
+          <TableHead className="border-r border-border">Reviewer</TableHead>
+          <TableHead className="text-center">Summary</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {[...Array(SKELETON_ROWS)].map((_, rowIdx) => (
+          <TableRow key={rowIdx} className="hover:bg-transparent">
+            {SKELETON_WIDTHS[rowIdx].map((w, colIdx) => (
+              <TableCell
+                key={colIdx}
+                className={
+                  colIdx === 0 ? "border-r border-border" :
+                  colIdx === 1 ? "border-r border-border/50" :
+                  colIdx === 4 || colIdx === 6 || colIdx === 8 ? "border-r border-border" :
+                  undefined
+                }
+              >
+                {colIdx === 3 || colIdx === 5 || colIdx === 7 ? (
+                  <Skeleton className={`h-6 ${w} rounded-full`} />
+                ) : (
+                  <Skeleton className={`h-4 ${w} rounded`} />
+                )}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }
+
+const ROW_DELAYS = ["animation-delay-0", "animation-delay-1", "animation-delay-2", "animation-delay-3", "animation-delay-4"];
 
 export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
   if (loading) return <TableSkeleton />;
@@ -89,7 +148,10 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
         </TableHeader>
         <TableBody>
           {data.map((row, idx) => (
-            <TableRow key={idx}>
+            <TableRow
+              key={idx}
+              className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}`}
+            >
               {/* Advisory Type */}
               <TableCell className="border-r border-border font-medium">
                 <Tooltip>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -67,3 +67,24 @@
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
 }
+
+@keyframes row-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-row-in {
+  animation: row-in 0.35s ease-out both;
+}
+
+.animation-delay-0 { animation-delay: 0ms; }
+.animation-delay-1 { animation-delay: 80ms; }
+.animation-delay-2 { animation-delay: 160ms; }
+.animation-delay-3 { animation-delay: 240ms; }
+.animation-delay-4 { animation-delay: 320ms; }


### PR DESCRIPTION
## Summary
- Replace generic skeleton bars with a structured table skeleton that mirrors the real table layout (real headers, varied cell widths, pill shapes for badge columns)
- Add staggered row-in animation when data loads — rows slide up with 80ms delays for a progressive reveal effect

## Test plan
- [ ] Load a release page — skeleton should show real table headers with shaped placeholders
- [ ] Once data loads, rows should animate in one by one with a subtle slide-up
- [ ] Switch versions in sidebar — skeleton appears, then rows animate in again
- [ ] Verify both light and dark mode look correct

Generated with [Claude Code](https://claude.com/claude-code)