### PR TITLE
ART-19085: Use batch errata endpoint and add error handling to advisory table

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,9 @@ NEXT_PUBLIC_CURRENT_ADVISORY_IDS_FOR_A_BRANCH_OCP_BUILD_DATA = /release/branch/?
 # get advisory details for an advisory id
 NEXT_PUBLIC_ADVISORY_DETAILS_FOR_AN_ADVISORY_ID = /errata/advisory/?type=advisory&id=
 
+# get advisory details for multiple advisory ids in one request
+NEXT_PUBLIC_BATCH_ADVISORY_DETAILS = /errata/advisory/batch/?ids=
+
 # get errata user details
 NEXT_PUBLIC_USER_DETAILS_FOR_A_USER_ID = /errata/user/?type=user&id=
 

--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -25,6 +25,12 @@ function advisory_details_for_advisory_id(advisory_id) {
     return makeApiCall(url, 'GET', headers);
 }
 
+function batch_advisory_details(advisory_ids) {
+    const ids = advisory_ids.join(',');
+    const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}${process.env.NEXT_PUBLIC_BATCH_ADVISORY_DETAILS}${ids}`;
+    return makeApiCall(url, 'GET', headers);
+}
+
 function user_details_for_user_id(user_id) {
     const url = `${process.env.NEXT_PUBLIC_USER_DETAILS_FOR_A_USER_ID}${user_id}`;
     return makeApiCall(url, 'GET', headers);
@@ -62,6 +68,7 @@ module.exports = {
     remaining_git_requests,
     advisory_ids_for_branch,
     advisory_details_for_advisory_id,
+    batch_advisory_details,
     user_details_for_user_id,
     gaVersion
 };

--- a/components/dashboard/AdvisoryTable.tsx
+++ b/components/dashboard/AdvisoryTable.tsx
@@ -19,15 +19,16 @@ import {
 interface AdvisoryRow {
   advisory_type: string;
   errata_id: number;
-  advisory_type_main: string;
-  status: string;
-  publish_date: string;
-  synopsis: string;
-  doc_complete: string;
-  doc_reviewer_realname: string;
-  security_approved: string;
-  product_security_reviewer_realname: string;
-  bug_summary: Array<{ bug_status: string; count: number }>;
+  advisory_type_main?: string;
+  status?: string;
+  publish_date?: string;
+  synopsis?: string;
+  doc_complete?: string;
+  doc_reviewer_realname?: string;
+  security_approved?: string;
+  product_security_reviewer_realname?: string;
+  bug_summary?: Array<{ bug_status: string; count: number }>;
+  error?: string;
 }
 
 interface AdvisoryTableProps {
@@ -147,85 +148,112 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {data.map((row, idx) => (
-            <TableRow
-              key={idx}
-              className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}`}
-            >
-              {/* Advisory Type */}
-              <TableCell className="border-r border-border font-medium">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="cursor-default">
-                      {row.advisory_type.charAt(0).toUpperCase() +
-                        row.advisory_type.slice(1)}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>{row.synopsis}</TooltipContent>
-                </Tooltip>
-              </TableCell>
-
-              {/* Errata ID */}
-              <TableCell className="border-r border-border/50 font-mono">
-                <a
-                  href={`https://errata.devel.redhat.com/advisory/${row.errata_id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-accent transition-colors duration-100 hover:text-accent/80"
+          {data.map((row, idx) => {
+            if (row.error) {
+              return (
+                <TableRow
+                  key={idx}
+                  className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}`}
                 >
-                  {row.errata_id}
-                </a>
-              </TableCell>
+                  <TableCell className="border-r border-border font-medium">
+                    {row.advisory_type.charAt(0).toUpperCase() +
+                      row.advisory_type.slice(1)}
+                  </TableCell>
+                  <TableCell className="border-r border-border/50 font-mono">
+                    {row.errata_id}
+                  </TableCell>
+                  <TableCell colSpan={8}>
+                    <div className="flex items-center gap-2 text-sm text-destructive">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 flex-shrink-0">
+                        <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                      </svg>
+                      Failed to load: {row.error}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            }
 
-              {/* Advisory Type Main */}
-              <TableCell className="text-muted-foreground">
-                {row.advisory_type_main?.toUpperCase()}
-              </TableCell>
+            return (
+              <TableRow
+                key={idx}
+                className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}`}
+              >
+                {/* Advisory Type */}
+                <TableCell className="border-r border-border font-medium">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="cursor-default">
+                        {row.advisory_type.charAt(0).toUpperCase() +
+                          row.advisory_type.slice(1)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{row.synopsis}</TooltipContent>
+                  </Tooltip>
+                </TableCell>
 
-              {/* Status */}
-              <TableCell>
-                <StatusBadge status={row.status} />
-              </TableCell>
+                {/* Errata ID */}
+                <TableCell className="border-r border-border/50 font-mono">
+                  <a
+                    href={`https://errata.devel.redhat.com/advisory/${row.errata_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent transition-colors duration-100 hover:text-accent/80"
+                  >
+                    {row.errata_id}
+                  </a>
+                </TableCell>
 
-              {/* Release Date */}
-              <TableCell className="border-r border-border text-muted-foreground">
-                {row.publish_date}
-              </TableCell>
+                {/* Advisory Type Main */}
+                <TableCell className="text-muted-foreground">
+                  {row.advisory_type_main?.toUpperCase()}
+                </TableCell>
 
-              {/* Doc Approval */}
-              <TableCell>
-                <StatusBadge status={row.doc_complete} />
-              </TableCell>
+                {/* Status */}
+                <TableCell>
+                  <StatusBadge status={row.status} />
+                </TableCell>
 
-              {/* Doc Reviewer */}
-              <TableCell className="border-r border-border text-base text-muted-foreground">
-                {row.doc_reviewer_realname || "Not Available"}
-              </TableCell>
+                {/* Release Date */}
+                <TableCell className="border-r border-border text-muted-foreground">
+                  {row.publish_date}
+                </TableCell>
 
-              {/* Security Approval */}
-              <TableCell>
-                <StatusBadge status={row.security_approved} />
-              </TableCell>
+                {/* Doc Approval */}
+                <TableCell>
+                  <StatusBadge status={row.doc_complete} />
+                </TableCell>
 
-              {/* Security Reviewer */}
-              <TableCell className="border-r border-border text-base text-muted-foreground">
-                {row.product_security_reviewer_realname || "Not Available"}
-              </TableCell>
+                {/* Doc Reviewer */}
+                <TableCell className="border-r border-border text-base text-muted-foreground">
+                  {row.doc_reviewer_realname || "Not Available"}
+                </TableCell>
 
-              {/* Bug Summary */}
-              <TableCell className="text-center">
-                <div className="flex flex-wrap justify-center gap-1">
-                  {row.bug_summary?.map((bug, i) => (
-                    <StatusBadge
-                      key={i}
-                      status={bug.bug_status}
-                      count={bug.count}
-                    />
-                  ))}
-                </div>
-              </TableCell>
-            </TableRow>
-          ))}
+                {/* Security Approval */}
+                <TableCell>
+                  <StatusBadge status={row.security_approved} />
+                </TableCell>
+
+                {/* Security Reviewer */}
+                <TableCell className="border-r border-border text-base text-muted-foreground">
+                  {row.product_security_reviewer_realname || "Not Available"}
+                </TableCell>
+
+                {/* Bug Summary */}
+                <TableCell className="text-center">
+                  <div className="flex flex-wrap justify-center gap-1">
+                    {row.bug_summary?.map((bug, i) => (
+                      <StatusBadge
+                        key={i}
+                        status={bug.bug_status}
+                        count={bug.count}
+                      />
+                    ))}
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </TooltipProvider>

--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { advisory_details_for_advisory_id, advisory_ids_for_branch } from "../api_calls/release_calls";
+import { batch_advisory_details, advisory_ids_for_branch } from "../api_calls/release_calls";
 import { AdvisoryTable } from "../dashboard/AdvisoryTable";
 import { useRouter } from 'next/router';
 
@@ -19,27 +19,43 @@ function ReleaseBranchDetail(props) {
 
     const generateDataForEachAdvisory = useCallback(() => {
         setAdvisoryDetails([]);
-        const promises = overviewTableData.map((data) => {
-            return advisory_details_for_advisory_id(data.id).then(data_api => {
-                if (data_api["data"]) {
-                    return {
-                        advisory_details: data_api["data"]["advisory_details"],
-                        bug_details: data_api["data"]["bugs"],
-                        bug_summary: data_api["data"]["bug_summary"],
-                        type: data.type
-                    };
-                }
-                return null;
-            });
-        });
+        const advisoryIds = overviewTableData.map((data) => data.id);
 
-        Promise.all(promises)
-            .then((advisories_data) => {
-                advisories_data = advisories_data.filter(item => item !== null);
+        batch_advisory_details(advisoryIds)
+            .then((response) => {
+                const batchData = response["data"];
+                const advisories_data = overviewTableData.map((data) => {
+                    const entry = batchData?.[data.id];
+                    if (!entry || entry["status"] === "error") {
+                        return {
+                            type: data.type,
+                            error: entry?.["message"] || "Failed to load advisory data",
+                            errata_id: data.id,
+                        };
+                    }
+                    if (entry["data"]) {
+                        return {
+                            advisory_details: entry["data"]["advisory_details"],
+                            bug_details: entry["data"]["bugs"],
+                            bug_summary: entry["data"]["bug_summary"],
+                            type: data.type,
+                        };
+                    }
+                    return null;
+                }).filter(item => item !== null);
+
                 advisories_data.sort((a, b) => {
                     return FIXED_ORDER.indexOf(a.type) - FIXED_ORDER.indexOf(b.type);
                 });
                 setAdvisoryDetails(advisories_data);
+            })
+            .catch(() => {
+                const errorRows = overviewTableData.map((data) => ({
+                    type: data.type,
+                    error: "Network error — could not reach the server",
+                    errata_id: data.id,
+                }));
+                setAdvisoryDetails(errorRows);
             })
             .finally(() => {
                 setIsLoading(false);
@@ -131,6 +147,13 @@ function ReleaseBranchDetail(props) {
         if (!advisoryDetails || advisoryDetails.length === 0) return [];
 
         return advisoryDetails.map((data) => {
+            if (data.error) {
+                return {
+                    advisory_type: data.type,
+                    errata_id: data.errata_id,
+                    error: data.error,
+                };
+            }
             const details = data.advisory_details[0];
             return {
                 advisory_type: data.type,


### PR DESCRIPTION
## Summary
- Switch from N individual `advisory_details_for_advisory_id()` calls to a single `batch_advisory_details()` request, cutting frontend-to-backend round-trips from ~5 to 1
- Add inline error messages per advisory row when fetches fail (timeout, connection error, etc.) instead of silently filtering them out
- Add `NEXT_PUBLIC_BATCH_ADVISORY_DETAILS` env var for the new batch endpoint

**Depends on:** openshift-eng/art-dashboard-server#179 (backend batch endpoint)

## Test plan
- [x] Frontend compiles without errors
- [x] Advisory table renders correctly with batch data
- [x] Error rows show "Failed to load: ..." message with warning icon when backend returns errors
- [x] Network-level failures show "Network error" message for all rows
- [ ] Verify on staging that advisory data loads correctly with the batch endpoint


Made with [Cursor](https://cursor.com)