### PR TITLE
Add shipment advisory rows to release page

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,9 @@ NEXT_PUBLIC_BATCH_ADVISORY_DETAILS = /errata/advisory/batch/?ids=
 # get errata user details
 NEXT_PUBLIC_USER_DETAILS_FOR_A_USER_ID = /errata/user/?type=user&id=
 
+# get shipment status
+NEXT_PUBLIC_SHIPMENT_STATUS_ENDPOINT = /shipment/status/
+
 # run environment
 NEXT_PUBLIC_RUN_ENV=prod
 

--- a/components/api_calls/release_calls.js
+++ b/components/api_calls/release_calls.js
@@ -36,6 +36,11 @@ function user_details_for_user_id(user_id) {
     return makeApiCall(url, 'GET', headers);
 }
 
+function shipment_status(mr_url, branch, assembly) {
+    const url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}${process.env.NEXT_PUBLIC_SHIPMENT_STATUS_ENDPOINT}?url=${encodeURIComponent(mr_url)}&branch=${branch}&assembly=${assembly}`;
+    return makeApiCall(url, 'GET', headers);
+}
+
 function gaVersion() {
     const currentTime = new Date().getTime();  // Moved the definition up
 
@@ -70,5 +75,6 @@ module.exports = {
     advisory_details_for_advisory_id,
     batch_advisory_details,
     user_details_for_user_id,
+    shipment_status,
     gaVersion
 };

--- a/components/dashboard/AdvisoryTable.tsx
+++ b/components/dashboard/AdvisoryTable.tsx
@@ -18,17 +18,23 @@ import {
 
 interface AdvisoryRow {
   advisory_type: string;
-  errata_id: number;
+  errata_id?: number;
   advisory_type_main?: string;
   status?: string;
   publish_date?: string;
   synopsis?: string;
   doc_complete?: string;
   doc_reviewer_realname?: string;
-  security_approved?: string;
-  product_security_reviewer_realname?: string;
   bug_summary?: Array<{ bug_status: string; count: number }>;
   error?: string;
+  is_shipment?: boolean;
+  shipment_status?: string;
+  shipment_url?: string;
+  stage_advisory_url?: string;
+  prod_advisory_url?: string;
+  release_date?: string;
+  doc_approved?: boolean;
+  doc_reviewer?: string;
 }
 
 interface AdvisoryTableProps {
@@ -39,11 +45,11 @@ interface AdvisoryTableProps {
 const SKELETON_ROWS = 5;
 
 const SKELETON_WIDTHS = [
-  ["w-16", "w-14", "w-20", "w-12", "w-24", "w-20", "w-24", "w-20", "w-24", "w-16"],
-  ["w-10", "w-14", "w-16", "w-14", "w-24", "w-24", "w-28", "w-24", "w-28", "w-20"],
-  ["w-14", "w-14", "w-14", "w-16", "w-24", "w-16", "w-20", "w-16", "w-20", "w-24"],
-  ["w-20", "w-14", "w-20", "w-10", "w-24", "w-20", "w-28", "w-20", "w-28", "w-12"],
-  ["w-16", "w-14", "w-12", "w-14", "w-24", "w-16", "w-24", "w-16", "w-24", "w-16"],
+  ["w-16", "w-14", "w-20", "w-12", "w-24", "w-20", "w-24", "w-16"],
+  ["w-10", "w-14", "w-16", "w-14", "w-24", "w-24", "w-28", "w-20"],
+  ["w-14", "w-14", "w-14", "w-16", "w-24", "w-16", "w-20", "w-24"],
+  ["w-20", "w-14", "w-20", "w-10", "w-24", "w-20", "w-28", "w-12"],
+  ["w-16", "w-14", "w-12", "w-14", "w-24", "w-16", "w-24", "w-16"],
 ];
 
 function TableSkeleton() {
@@ -58,19 +64,14 @@ function TableSkeleton() {
           <TableHead colSpan={2} className="border-r border-border text-center">
             Doc
           </TableHead>
-          <TableHead colSpan={2} className="border-r border-border text-center">
-            Product Security
-          </TableHead>
           <TableHead className="text-center">Bugs</TableHead>
         </TableRow>
         <TableRow className="border-b border-border bg-card hover:bg-transparent dark:bg-zinc-950/50">
           <TableHead className="border-r border-border">Type</TableHead>
-          <TableHead className="border-r border-border/50">Errata ID</TableHead>
+          <TableHead className="border-r border-border/50">Advisory ID</TableHead>
           <TableHead>Type</TableHead>
           <TableHead>Status</TableHead>
           <TableHead className="border-r border-border">Release Date</TableHead>
-          <TableHead>Approval</TableHead>
-          <TableHead className="border-r border-border">Reviewer</TableHead>
           <TableHead>Approval</TableHead>
           <TableHead className="border-r border-border">Reviewer</TableHead>
           <TableHead className="text-center">Summary</TableHead>
@@ -85,11 +86,11 @@ function TableSkeleton() {
                 className={
                   colIdx === 0 ? "border-r border-border" :
                   colIdx === 1 ? "border-r border-border/50" :
-                  colIdx === 4 || colIdx === 6 || colIdx === 8 ? "border-r border-border" :
+                  colIdx === 4 || colIdx === 6 ? "border-r border-border" :
                   undefined
                 }
               >
-                {colIdx === 3 || colIdx === 5 || colIdx === 7 ? (
+                {colIdx === 3 || colIdx === 5 ? (
                   <Skeleton className={`h-6 ${w} rounded-full`} />
                 ) : (
                   <Skeleton className={`h-4 ${w} rounded`} />
@@ -105,6 +106,51 @@ function TableSkeleton() {
 
 const ROW_DELAYS = ["animation-delay-0", "animation-delay-1", "animation-delay-2", "animation-delay-3", "animation-delay-4"];
 
+function renderAdvisoryId(row: AdvisoryRow) {
+  if (row.is_shipment) {
+    const status = row.shipment_status;
+    if (status === "SHIPPED_LIVE" && row.prod_advisory_url) {
+      return (
+        <a
+          href={row.prod_advisory_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent transition-colors duration-100 hover:text-accent/80"
+        >
+          {row.errata_id}
+        </a>
+      );
+    }
+    if (status === "Staged" && row.stage_advisory_url) {
+      return (
+        <a
+          href={row.stage_advisory_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent transition-colors duration-100 hover:text-accent/80"
+        >
+          {row.errata_id}
+        </a>
+      );
+    }
+    if (!row.errata_id) {
+      return <span className="text-muted-foreground">--</span>;
+    }
+    return <span>{row.errata_id}</span>;
+  }
+
+  return (
+    <a
+      href={`https://errata.devel.redhat.com/advisory/${row.errata_id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-accent transition-colors duration-100 hover:text-accent/80"
+    >
+      {row.errata_id}
+    </a>
+  );
+}
+
 export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
   if (loading) return <TableSkeleton />;
   if (!data || data.length === 0) {
@@ -119,7 +165,6 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
     <TooltipProvider delayDuration={200}>
       <Table>
         <TableHeader>
-          {/* Group headers */}
           <TableRow className="border-b border-border hover:bg-transparent">
             <TableHead className="border-r border-border">Advisory</TableHead>
             <TableHead colSpan={4} className="border-r border-border text-center">
@@ -128,20 +173,14 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
             <TableHead colSpan={2} className="border-r border-border text-center">
               Doc
             </TableHead>
-            <TableHead colSpan={2} className="border-r border-border text-center">
-              Product Security
-            </TableHead>
             <TableHead className="text-center">Bugs</TableHead>
           </TableRow>
-          {/* Sub-headers */}
           <TableRow className="border-b border-border bg-card hover:bg-transparent dark:bg-zinc-950/50">
             <TableHead className="border-r border-border">Type</TableHead>
-            <TableHead className="border-r border-border/50">Errata ID</TableHead>
+            <TableHead className="border-r border-border/50">Advisory ID</TableHead>
             <TableHead>Type</TableHead>
             <TableHead>Status</TableHead>
             <TableHead className="border-r border-border">Release Date</TableHead>
-            <TableHead>Approval</TableHead>
-            <TableHead className="border-r border-border">Reviewer</TableHead>
             <TableHead>Approval</TableHead>
             <TableHead className="border-r border-border">Reviewer</TableHead>
             <TableHead className="text-center">Summary</TableHead>
@@ -162,7 +201,7 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
                   <TableCell className="border-r border-border/50 font-mono">
                     {row.errata_id}
                   </TableCell>
-                  <TableCell colSpan={8}>
+                  <TableCell colSpan={6}>
                     <div className="flex items-center gap-2 text-sm text-destructive">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 flex-shrink-0">
                         <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
@@ -177,9 +216,8 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
             return (
               <TableRow
                 key={idx}
-                className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}`}
+                className={`animate-row-in ${ROW_DELAYS[idx] || ROW_DELAYS[ROW_DELAYS.length - 1]}${row.is_shipment ? " bg-accent/5" : ""}`}
               >
-                {/* Advisory Type */}
                 <TableCell className="border-r border-border font-medium">
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -192,64 +230,56 @@ export function AdvisoryTable({ data, loading }: AdvisoryTableProps) {
                   </Tooltip>
                 </TableCell>
 
-                {/* Errata ID */}
                 <TableCell className="border-r border-border/50 font-mono">
-                  <a
-                    href={`https://errata.devel.redhat.com/advisory/${row.errata_id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-accent transition-colors duration-100 hover:text-accent/80"
-                  >
-                    {row.errata_id}
-                  </a>
+                  {renderAdvisoryId(row)}
                 </TableCell>
 
-                {/* Advisory Type Main */}
                 <TableCell className="text-muted-foreground">
                   {row.advisory_type_main?.toUpperCase()}
                 </TableCell>
 
-                {/* Status */}
                 <TableCell>
-                  <StatusBadge status={row.status} />
+                  {(row.is_shipment ? row.shipment_status : row.status) ? (
+                    <StatusBadge status={row.is_shipment ? row.shipment_status! : row.status} />
+                  ) : (
+                    <span className="text-muted-foreground">--</span>
+                  )}
                 </TableCell>
 
-                {/* Release Date */}
                 <TableCell className="border-r border-border text-muted-foreground">
-                  {row.publish_date}
+                  {(row.is_shipment ? (row.release_date || row.publish_date) : row.publish_date) || "--"}
                 </TableCell>
 
-                {/* Doc Approval */}
                 <TableCell>
-                  <StatusBadge status={row.doc_complete} />
+                  {row.is_shipment ? (
+                    <StatusBadge status={row.doc_approved ? "Approved" : "Not Approved"} />
+                  ) : row.doc_complete ? (
+                    <StatusBadge status={row.doc_complete} />
+                  ) : (
+                    <span className="text-muted-foreground">--</span>
+                  )}
                 </TableCell>
 
-                {/* Doc Reviewer */}
                 <TableCell className="border-r border-border text-base text-muted-foreground">
-                  {row.doc_reviewer_realname || "Not Available"}
+                  {row.is_shipment
+                    ? (row.doc_reviewer || "Not Available")
+                    : (row.doc_reviewer_realname || "Not Available")}
                 </TableCell>
 
-                {/* Security Approval */}
-                <TableCell>
-                  <StatusBadge status={row.security_approved} />
-                </TableCell>
-
-                {/* Security Reviewer */}
-                <TableCell className="border-r border-border text-base text-muted-foreground">
-                  {row.product_security_reviewer_realname || "Not Available"}
-                </TableCell>
-
-                {/* Bug Summary */}
                 <TableCell className="text-center">
-                  <div className="flex flex-wrap justify-center gap-1">
-                    {row.bug_summary?.map((bug, i) => (
-                      <StatusBadge
-                        key={i}
-                        status={bug.bug_status}
-                        count={bug.count}
-                      />
-                    ))}
-                  </div>
+                  {row.is_shipment || !row.bug_summary?.length ? (
+                    <span className="text-muted-foreground">--</span>
+                  ) : (
+                    <div className="flex flex-wrap justify-center gap-1">
+                      {row.bug_summary.map((bug, i) => (
+                        <StatusBadge
+                          key={i}
+                          status={bug.bug_status}
+                          count={bug.count}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </TableCell>
               </TableRow>
             );

--- a/components/dashboard/StatusBadge.tsx
+++ b/components/dashboard/StatusBadge.tsx
@@ -12,10 +12,12 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   Requested: "info",
   ON_QA: "info",
   REL_PREP: "info",
-  Pending: "warning",
+  Staged: "warning",
+  Pending: "default",
   NEW_FILES: "warning",
   MODIFIED: "warning",
   "Not Requested": "default",
+  "Not Approved": "default",
 };
 
 function getVariant(status: string): StatusVariant {

--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { batch_advisory_details, advisory_ids_for_branch } from "../api_calls/release_calls";
+import { batch_advisory_details, advisory_ids_for_branch, shipment_status } from "../api_calls/release_calls";
 import { AdvisoryTable } from "../dashboard/AdvisoryTable";
 import { useRouter } from 'next/router';
 
@@ -9,6 +9,8 @@ function ReleaseBranchDetail(props) {
     const [advisoryDetails, setAdvisoryDetails] = useState(undefined);
     const [current, setCurrent] = useState(undefined);
     const [currentJira, setCurrentJira] = useState(undefined);
+    const [shipmentInfo, setShipmentInfo] = useState(null);
+    const [shipmentStatusData, setShipmentStatusData] = useState(null);
     const router = useRouter();
     const [currentPage, setCurrentPage] = useState(null);
     const [isRouterReady, setIsRouterReady] = useState(false);
@@ -68,6 +70,9 @@ function ReleaseBranchDetail(props) {
         if (!currentVersionKey) return;
 
         setCurrentJira(data[currentVersionKey][1]);
+
+        const shipment = data[currentVersionKey][2] || null;
+        setShipmentInfo(shipment);
 
         const tableData = Object.entries(data[currentVersionKey][0]).map(([type, id]) => ({
             type: type,
@@ -143,33 +148,82 @@ function ReleaseBranchDetail(props) {
         }
     }, [current, overviewTableData]);
 
-    const tableData = React.useMemo(() => {
-        if (!advisoryDetails || advisoryDetails.length === 0) return [];
+    useEffect(() => {
+        if (shipmentInfo && shipmentInfo.url && current) {
+            const branch = props.branch;
+            shipment_status(shipmentInfo.url, branch, current)
+                .then(data => {
+                    setShipmentStatusData(data);
+                })
+                .catch(err => {
+                    console.error('Error fetching shipment status:', err);
+                    setShipmentStatusData(null);
+                });
+        } else {
+            setShipmentStatusData(null);
+        }
+    }, [shipmentInfo, current, props.branch]);
 
-        return advisoryDetails.map((data) => {
-            if (data.error) {
-                return {
-                    advisory_type: data.type,
-                    errata_id: data.errata_id,
-                    error: data.error,
-                };
+    const tableData = React.useMemo(() => {
+        const rows = [];
+
+        if (shipmentInfo && shipmentInfo.advisories) {
+            const status = shipmentStatusData?.status || "Pending";
+            const approvals = shipmentStatusData?.approvals || {};
+            const docsApproval = approvals["Docs"] || {};
+            const advisoryFileData = shipmentStatusData?.advisories || {};
+
+            for (const adv of shipmentInfo.advisories) {
+                const fileData = advisoryFileData[adv.kind] || {};
+                rows.push({
+                    advisory_type: adv.kind,
+                    errata_id: fileData.live_id || adv.live_id,
+                    advisory_type_main: fileData.type || "",
+                    status: status,
+                    publish_date: shipmentInfo.release_date || "",
+                    synopsis: fileData.synopsis || "",
+                    doc_complete: docsApproval.approved ? "Approved" : "Not Approved",
+                    doc_reviewer_realname: docsApproval.approved_by || "Not Available",
+                    bug_summary: [],
+                    is_shipment: true,
+                    shipment_status: status,
+                    shipment_url: shipmentInfo.url,
+                    stage_advisory_url: fileData.stage_url || null,
+                    prod_advisory_url: fileData.prod_url || null,
+                    release_date: shipmentInfo.release_date || "",
+                    doc_approved: docsApproval.approved || false,
+                    doc_reviewer: docsApproval.approved_by || "Not Available",
+                });
             }
-            const details = data.advisory_details[0];
-            return {
-                advisory_type: data.type,
-                errata_id: details.id,
-                advisory_type_main: details.advisory_type,
-                status: details.status,
-                publish_date: details.publish_date,
-                synopsis: details.synopsis,
-                doc_complete: details.doc_complete,
-                doc_reviewer_realname: details.doc_reviewer_details?.realname || "Not Available",
-                security_approved: details.security_approved,
-                product_security_reviewer_realname: details.product_security_reviewer_details?.realname || "Not Available",
-                bug_summary: data.bug_summary,
-            };
-        });
-    }, [advisoryDetails]);
+        }
+
+        if (advisoryDetails && advisoryDetails.length > 0) {
+            for (const data of advisoryDetails) {
+                if (data.error) {
+                    rows.push({
+                        advisory_type: data.type,
+                        errata_id: data.errata_id,
+                        error: data.error,
+                    });
+                    continue;
+                }
+                const details = data.advisory_details[0];
+                rows.push({
+                    advisory_type: data.type,
+                    errata_id: details.id,
+                    advisory_type_main: details.advisory_type,
+                    status: details.status,
+                    publish_date: details.publish_date,
+                    synopsis: details.synopsis,
+                    doc_complete: details.doc_complete,
+                    doc_reviewer_realname: details.doc_reviewer_details?.realname || "Not Available",
+                    bug_summary: data.bug_summary,
+                });
+            }
+        }
+
+        return rows;
+    }, [advisoryDetails, shipmentInfo, shipmentStatusData]);
 
     useEffect(() => {
         if (props.onVersionInfo && current) {


### PR DESCRIPTION
## Summary
- Show image, extras, and metadata advisories from GitLab shipment MRs alongside existing errata advisories on the release page
- Rename "Errata ID" column to "Advisory ID" and remove deprecated "Product Security" columns
- Add `Pending`/`Staged`/`SHIPPED_LIVE` status badges for shipment advisories, with linked advisory URLs, advisory type (RHSA/RHBA), release date, and doc approval from MR approval state

## Test plan
- [ ] Navigate to a release version with shipment data (e.g., openshift-4.21, page 1) — verify Image/Extras/Metadata rows appear above errata rows
- [ ] Verify shipment rows show correct status badge, advisory type, release date, and doc approval
- [ ] Verify advisory ID links to prod URL when SHIPPED_LIVE, stage URL when Staged, or shows plain ID when Pending
- [ ] Verify errata rows (Rpm, Rhcos, Microshift) still display correctly with full details
- [ ] Verify error rows still render inline error messages when errata API fails
- [ ] Verify empty bug summary shows "--" instead of blank cell
- [ ] Requires companion backend PR: openshift-eng/art-dashboard-server#(backend PR number)


Made with [Cursor](https://cursor.com)