### PR TITLE
Clear stale advisory data when switching z-stream versions

### DIFF
--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -69,6 +69,9 @@ function ReleaseBranchDetail(props) {
         const currentVersionKey = versionKeys[page - 1];
         if (!currentVersionKey) return;
 
+        setAdvisoryDetails(undefined);
+        setShipmentStatusData(null);
+
         setCurrentJira(data[currentVersionKey][1]);
 
         const shipment = data[currentVersionKey][2] || null;


### PR DESCRIPTION
## Summary
- Reset advisoryDetails and shipmentStatusData when switching between z-stream versions so the table shows the loading skeleton instead of briefly flashing the previous version's rows

## Test plan
- [ ] Navigate to a release branch, click between different z-stream versions in the sidebar
- [ ] Verify the table shows the skeleton loader during transitions, not stale data from the previous version

Made with [Cursor](https://cursor.com)