### PR TITLE
Fix loading skeleton disappearing before all data is ready

### DIFF
--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -16,8 +16,16 @@ function ReleaseBranchDetail(props) {
     const [isRouterReady, setIsRouterReady] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [loadedBranch, setLoadedBranch] = useState(null);
+    const [errataLoaded, setErrataLoaded] = useState(false);
+    const [shipmentLoaded, setShipmentLoaded] = useState(false);
 
     const FIXED_ORDER = ["Extras", "Image", "Metadata", "Microshift", "Rpm"];
+
+    useEffect(() => {
+        if (errataLoaded && shipmentLoaded) {
+            setIsLoading(false);
+        }
+    }, [errataLoaded, shipmentLoaded]);
 
     const generateDataForEachAdvisory = useCallback(() => {
         setAdvisoryDetails([]);
@@ -60,7 +68,7 @@ function ReleaseBranchDetail(props) {
                 setAdvisoryDetails(errorRows);
             })
             .finally(() => {
-                setIsLoading(false);
+                setErrataLoaded(true);
             });
     }, [overviewTableData]);
 
@@ -69,6 +77,9 @@ function ReleaseBranchDetail(props) {
         const currentVersionKey = versionKeys[page - 1];
         if (!currentVersionKey) return;
 
+        setIsLoading(true);
+        setErrataLoaded(false);
+        setShipmentLoaded(false);
         setAdvisoryDetails(undefined);
         setShipmentStatusData(null);
 
@@ -76,6 +87,10 @@ function ReleaseBranchDetail(props) {
 
         const shipment = data[currentVersionKey][2] || null;
         setShipmentInfo(shipment);
+
+        if (!shipment || !shipment.url) {
+            setShipmentLoaded(true);
+        }
 
         const tableData = Object.entries(data[currentVersionKey][0]).map(([type, id]) => ({
             type: type,
@@ -114,6 +129,10 @@ function ReleaseBranchDetail(props) {
         const pageIndex = versionKeys.indexOf(versionKey);
         if (pageIndex === -1) return;
 
+        setIsLoading(true);
+        setAdvisoryDetails(undefined);
+        setShipmentStatusData(null);
+
         const newPage = pageIndex + 1;
         router.replace({
             pathname: router.pathname,
@@ -137,7 +156,6 @@ function ReleaseBranchDetail(props) {
     useEffect(() => {
         if (props.branch && currentPage !== null && isRouterReady) {
             if (branchData && loadedBranch === props.branch) {
-                setIsLoading(true);
                 loadVersionData(branchData, currentPage);
             } else {
                 getBranchData(props.branch, currentPage);
@@ -161,9 +179,13 @@ function ReleaseBranchDetail(props) {
                 .catch(err => {
                     console.error('Error fetching shipment status:', err);
                     setShipmentStatusData(null);
+                })
+                .finally(() => {
+                    setShipmentLoaded(true);
                 });
         } else {
             setShipmentStatusData(null);
+            setShipmentLoaded(true);
         }
     }, [shipmentInfo, current, props.branch]);
 


### PR DESCRIPTION
## Summary
- Track errata and shipment fetch completion independently with errataLoaded/shipmentLoaded flags
- Loading skeleton stays visible until both fetches complete, preventing partial data flash
- Clear stale advisory data immediately in handleVersionSelect and loadVersionData to prevent old rows from rendering during transitions

## Test plan
- [ ] Switch between z-stream versions rapidly -- skeleton should show until all columns are populated
- [ ] Verify versions without shipment data (older releases) don't get stuck loading
- [ ] Verify all columns (Advisory ID, Status, Type, Doc Approval, Release Date) appear together, not incrementally

Made with [Cursor](https://cursor.com)