### PR TITLE
Remove threat model assessment checkbox

### DIFF
--- a/components/self-service/new-content-checklist.tsx
+++ b/components/self-service/new-content-checklist.tsx
@@ -45,17 +45,6 @@ export function NewContentChecklist() {
       </Tooltip>
     </Box>
     <Box>
-      <FormControlLabel control={<Checkbox {...register("check_prodsec_review", {required: true})} />}
-                        label="You have performed a threat model assessment"/>
-      <Tooltip title={`ProdSec no longer performs an assessment, instead requiring a self-assessment from this link`}>
-        <IconButton color="primary" aria-label="help"
-                    href="https://spaces.redhat.com/spaces/PRODSEC/pages/388107958/Request+an+SD+Elements+Threat+Model+for+new+OCP+components"
-                    target="_blank">
-          <HelpIcon/>
-        </IconButton>
-      </Tooltip>
-    </Box>
-    <Box>
       <FormControlLabel control={<Checkbox {...register("check_alignment", {required: true})} />}
                         label="My image/rpm has aligned with Product Management / Docs / QE / Product Support"/>
       <Tooltip title={`While not a technical requirement for building a new component, please ensure that there is a shared understanding


### PR DESCRIPTION
Deprecating on the request of Hardik Vyas from ProdSec

## Summary
- Removes the threat model assessment checkbox from the new content onboarding checklist
- This check is no longer required in the flow

## Test plan
- [ ] Verify the new content checklist page loads without errors
- [ ] Confirm the remaining three checkboxes (DPTP/CI, Operator Hub, PM/Docs/QE/Support alignment) still function correctly
- [ ] Confirm the "Continue" button enables only after all remaining checkboxes are checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)