### PR TITLE
ART-19365: Add pipeline status display to release detail view

### DIFF
--- a/components/dashboard/PipelineStatus.tsx
+++ b/components/dashboard/PipelineStatus.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Badge } from "../ui/badge";
+import { Skeleton } from "../ui/skeleton";
+
+interface PipelineStatusProps {
+  status: Record<string, boolean>;
+  loading?: boolean;
+}
+
+const PIPELINE_STEPS = [
+  { key: "gen_assembly", label: "Gen Assembly" },
+  { key: "prepare_release", label: "Prepare Release" },
+  { key: "build_sync", label: "Build Sync" },
+  { key: "promoted", label: "Promoted" },
+];
+
+export function PipelineStatus({ status, loading }: PipelineStatusProps) {
+  if (loading) {
+    return (
+      <div className="mb-4 flex items-center gap-2">
+        {PIPELINE_STEPS.map((step) => (
+          <Skeleton key={step.key} className="h-7 w-28 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!status || Object.keys(status).length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-4 flex items-center gap-2">
+      <span className="mr-1 text-sm text-muted-foreground">Pipeline:</span>
+      {PIPELINE_STEPS.map((step, idx) => {
+        const done = status[step.key] === true;
+        return (
+          <React.Fragment key={step.key}>
+            {idx > 0 && (
+              <svg
+                className={`h-3 w-3 flex-shrink-0 ${done || status[PIPELINE_STEPS[idx - 1]?.key] ? "text-muted-foreground" : "text-muted-foreground/30"}`}
+                viewBox="0 0 12 12"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M4.5 2.5L8 6L4.5 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+            <Badge variant={done ? "success" : "default"}>
+              {done && (
+                <svg className="mr-1 h-3 w-3" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+              {step.label}
+            </Badge>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/release/release_branch_detail.js
+++ b/components/release/release_branch_detail.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { batch_advisory_details, advisory_ids_for_branch, shipment_status } from "../api_calls/release_calls";
 import { AdvisoryTable } from "../dashboard/AdvisoryTable";
+import { PipelineStatus } from "../dashboard/PipelineStatus";
 import { useRouter } from 'next/router';
 
 function ReleaseBranchDetail(props) {
@@ -11,6 +12,7 @@ function ReleaseBranchDetail(props) {
     const [currentJira, setCurrentJira] = useState(undefined);
     const [shipmentInfo, setShipmentInfo] = useState(null);
     const [shipmentStatusData, setShipmentStatusData] = useState(null);
+    const [pipelineStatus, setPipelineStatus] = useState({});
     const router = useRouter();
     const [currentPage, setCurrentPage] = useState(null);
     const [isRouterReady, setIsRouterReady] = useState(false);
@@ -87,6 +89,9 @@ function ReleaseBranchDetail(props) {
 
         const shipment = data[currentVersionKey][2] || null;
         setShipmentInfo(shipment);
+
+        const status = data[currentVersionKey][3] || {};
+        setPipelineStatus(status);
 
         if (!shipment || !shipment.url) {
             setShipmentLoaded(true);
@@ -258,6 +263,7 @@ function ReleaseBranchDetail(props) {
 
     return (
         <div className="flex-1 overflow-auto px-5 py-4">
+            <PipelineStatus status={pipelineStatus} loading={isLoading} />
             <AdvisoryTable data={tableData} loading={isLoading} />
         </div>
     );


### PR DESCRIPTION
## Summary
- Add `PipelineStatus` component showing 4 pipeline step badges (Gen Assembly, Prepare Release, Build Sync, Promoted)
- Integrate into `release_branch_detail.js` above the AdvisoryTable
- Green/success badges for completed steps, grey/default for pending
- Hidden when no status data exists (backwards compatible)

## Context
Companion to the art-tools and art-dashboard-server PRs that add and surface pipeline job completion status fields from releases.yml.

## Test plan
- [ ] Verify PipelineStatus renders correctly with various status combinations
- [ ] Verify component is hidden when status object is empty
- [ ] Verify existing advisory/shipment table display is unaffected
- [ ] Visual check: badges display correctly in both light and dark themes

Generated with [Claude Code](https://claude.com/claude-code)