### PR TITLE
ART-19650: Fix group input to use client-side filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,12 +121,20 @@ class KonfluxBuildHistory(Flask):
                 query_params,
                 outcomes=[
                     # PascalCase (old format)
-                    'Success', 'BuildError', 'ItsError', 'ReleaseError', 'Pending',
+                    'Success',
+                    'BuildError',
+                    'ItsError',
+                    'ReleaseError',
+                    'Pending',
                     # snake_case (new art-tools format)
-                    'success', 'build_error', 'its_error', 'release_error', 'pending',
+                    'success',
+                    'build_error',
+                    'its_error',
+                    'release_error',
+                    'pending',
                     # Legacy
-                    'failure'
-                ]
+                    'failure',
+                ],
             )
 
             # Check if the request is an AJAX request
@@ -251,12 +259,24 @@ class KonfluxBuildHistory(Flask):
             record_id = request.args.get('record_id')
             group = request.args.get('group')
             redis_key = self.redis_build_record_key(record_id) if record_id else self.redis_build_key(nvr)
-            search_outcomes = [outcome] if outcome else [
-                # PascalCase, snake_case, and legacy
-                'Success', 'BuildError', 'ItsError', 'ReleaseError', 'Pending',
-                'success', 'build_error', 'its_error', 'release_error', 'pending',
-                'failure'
-            ]
+            search_outcomes = (
+                [outcome]
+                if outcome
+                else [
+                    # PascalCase, snake_case, and legacy
+                    'Success',
+                    'BuildError',
+                    'ItsError',
+                    'ReleaseError',
+                    'Pending',
+                    'success',
+                    'build_error',
+                    'its_error',
+                    'release_error',
+                    'pending',
+                    'failure',
+                ]
+            )
 
             if not nvr or not record_id:
                 error_message = 'Both nvr and record_id are required to view build details.'
@@ -402,11 +422,21 @@ class KonfluxBuildHistory(Flask):
                     try:
                         db = KonfluxDb()
                         db.bind(record_class)
-                        where = {'outcome': [
-                            'Success', 'BuildError', 'ItsError', 'ReleaseError', 'Pending',
-                            'success', 'build_error', 'its_error', 'release_error', 'pending',
-                            'failure'
-                        ]}
+                        where = {
+                            'outcome': [
+                                'Success',
+                                'BuildError',
+                                'ItsError',
+                                'ReleaseError',
+                                'Pending',
+                                'success',
+                                'build_error',
+                                'its_error',
+                                'release_error',
+                                'pending',
+                                'failure',
+                            ]
+                        }
                         if record_id:
                             where['record_id'] = record_id
                         else:
@@ -525,11 +555,22 @@ class KonfluxBuildHistory(Flask):
                 try:
                     db = KonfluxDb()
                     db.bind(record_class)
-                    where = {'record_id': record_id, 'outcome': [
-                        'Success', 'BuildError', 'ItsError', 'ReleaseError', 'Pending',
-                        'success', 'build_error', 'its_error', 'release_error', 'pending',
-                        'failure'
-                    ]}
+                    where = {
+                        'record_id': record_id,
+                        'outcome': [
+                            'Success',
+                            'BuildError',
+                            'ItsError',
+                            'ReleaseError',
+                            'Pending',
+                            'success',
+                            'build_error',
+                            'its_error',
+                            'release_error',
+                            'pending',
+                            'failure',
+                        ],
+                    }
                     if group:
                         where['group'] = group
                     builds = [build async for build in db.search_builds_by_fields(where=where, limit=1)]

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1084,12 +1084,18 @@ function matchesFilters(result, filterParams) {
     }
 
     for (let [key, value] of filterParams.entries()) {
-        if (!value) continue; // Skip empty filter values
-
         // Skip outcome - already handled above
         if (key === "outcome") {
             continue;
-        } else if (key == 'group') {
+        }
+
+        if (!value) continue; // Skip empty filter values (but check outcome first since it's handled separately)
+
+        if (key == 'group') {
+            // Support wildcard '*' for group, and treat empty as match-all
+            if (value === '*') {
+                continue; // Match all groups
+            }
             if (result['group'] != value) {
                 return false;
             }
@@ -1191,6 +1197,8 @@ function setupStaticAutocomplete(input, dropdown, options) {
                 input.value = item;
                 dropdown.style.display = 'none';
                 highlightedIdx = -1;
+                // Trigger change event to update filter button visibility
+                input.dispatchEvent(new Event('change', { bubbles: true }));
             });
 
             dropdown.appendChild(div);
@@ -1248,6 +1256,8 @@ function setupStaticAutocomplete(input, dropdown, options) {
                 e.preventDefault();
                 if (highlightedIdx >= 0 && items[highlightedIdx]) {
                     input.value = items[highlightedIdx].dataset.value;
+                    // Trigger change event to update filter button visibility
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
                 }
                 // If no item is highlighted, keep the user's custom value
                 hideDropdown();
@@ -1293,6 +1303,8 @@ function setupSourceRepoAutocomplete(input, dropdown) {
                 input.value = repo;
                 dropdown.style.display = 'none';
                 highlightedIdx = -1;
+                // Trigger change event to update filter button visibility
+                input.dispatchEvent(new Event('change', { bubbles: true }));
             });
 
             dropdown.appendChild(item);
@@ -1350,6 +1362,8 @@ function setupSourceRepoAutocomplete(input, dropdown) {
                 e.preventDefault();
                 if (highlightedIdx >= 0 && items[highlightedIdx]) {
                     input.value = items[highlightedIdx].textContent;
+                    // Trigger change event to update filter button visibility
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
                 }
                 // If no item is highlighted, keep the user's custom value
                 hideDropdown();
@@ -1396,6 +1410,8 @@ function setupAutocomplete(input, dropdown) {
                 input.value = branch;
                 dropdown.style.display = 'none';
                 highlightedIndex = -1;
+                // Trigger change event to update filter button visibility
+                input.dispatchEvent(new Event('change', { bubbles: true }));
             });
 
             dropdown.appendChild(item);
@@ -1461,6 +1477,8 @@ function setupAutocomplete(input, dropdown) {
                 if (highlightedIndex >= 0 && items[highlightedIndex]) {
                     // Select the highlighted item
                     input.value = items[highlightedIndex].textContent;
+                    // Trigger change event to update filter button visibility
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
                 }
                 // If no item is highlighted, keep the user's custom value
                 hideDropdown();

--- a/tests/static/index.test.js
+++ b/tests/static/index.test.js
@@ -102,11 +102,18 @@ describe('Index Page - Filter Matching Logic', () => {
         }
 
         for (let [key, value] of filterParams.entries()) {
-            if (!value) continue;
-
+            // Skip outcome - already handled above
             if (key === "outcome") {
                 continue;
-            } else if (key == 'group') {
+            }
+
+            if (!value) continue; // Skip empty filter values (but check outcome first since it's handled separately)
+
+            if (key == 'group') {
+                // Support wildcard '*' for group, and treat empty as match-all
+                if (value === '*') {
+                    continue; // Match all groups
+                }
                 if (result['group'] != value) {
                     return false;
                 }
@@ -170,6 +177,31 @@ describe('Index Page - Filter Matching Logic', () => {
         const result = { assembly: 'stream' };
         const filterParams = new URLSearchParams([['assembly', '*']]);
 
+        expect(matchesFilters(result, filterParams)).toBe(true);
+    });
+
+    test('matchesFilters handles group wildcard', () => {
+        const result = { group: 'openshift-4.15' };
+        const filterParams = new URLSearchParams([['group', '*']]);
+
+        expect(matchesFilters(result, filterParams)).toBe(true);
+    });
+
+    test('matchesFilters handles group exact match', () => {
+        const result = { group: 'openshift-4.15' };
+
+        const filterParams1 = new URLSearchParams([['group', 'openshift-4.15']]);
+        const filterParams2 = new URLSearchParams([['group', 'openshift-4.16']]);
+
+        expect(matchesFilters(result, filterParams1)).toBe(true);
+        expect(matchesFilters(result, filterParams2)).toBe(false);
+    });
+
+    test('matchesFilters handles empty group filter', () => {
+        const result = { group: 'openshift-4.15' };
+        const filterParams = new URLSearchParams([['group', '']]);
+
+        // Empty value should be skipped, matching all groups
         expect(matchesFilters(result, filterParams)).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
Enables client-side filtering by group for already-cached results, avoiding unnecessary BigQuery queries.

## The Problem
Currently, group filtering **works** but always requires fetching from BigQuery. This fix enables filtering cached results client-side.

### Current Behavior (Before Fix)
1. User searches for builds (e.g., name="openshift-cli", no group filter)
2. BigQuery returns 500 builds across multiple groups (4.15, 4.16, 4.17, etc.)
3. Results are cached in browser
4. **User wants to see only 4.16 builds from the cached results**
5. User changes Group field to "openshift-4.16"
6. ❌ "Filter view" button doesn't appear (autocomplete doesn't trigger change events)
7. ❌ User forced to click "Fetch from DB" again
8. ❌ **New BigQuery query** runs even though data is already cached

### New Behavior (After Fix)
1. User searches for builds (e.g., name="openshift-cli", no group filter)
2. BigQuery returns 500 builds across multiple groups
3. Results are cached in browser
4. **User wants to see only 4.16 builds from the cached results**
5. User changes Group field to "openshift-4.16" (via autocomplete or typing)
6. ✅ "Filter view" button appears (autocomplete now triggers change events)
7. ✅ User clicks "Filter view"
8. ✅ **Results filtered client-side from cache** - no BigQuery query

## Root Cause
The group field was already supported in the `matchesFilters()` client-side filtering function, but the UI wasn't making it discoverable because:

1. **Autocomplete selections didn't trigger form change events** - selecting from dropdown updated the value but didn't dispatch `change` event
2. **Missing wildcard support** - group field didn't support `*` to match all groups (unlike assembly field)

## Solution
### Client-side filtering enhancements
- Added wildcard `*` support for group field (consistent with assembly field)
- Fixed 3 autocomplete functions to dispatch `change` events when selections are made:
  - `setupAutocomplete()` - used for Group field
  - `setupStaticAutocomplete()` - used for Assembly field
  - `setupSourceRepoAutocomplete()` - used for Source Repository field
- Now properly shows "Filter view" button when these fields change via autocomplete

### Files Changed
- `static/js/index.js`: Enhanced group filtering + event dispatching in 3 autocomplete functions
- `tests/static/index.test.js`: Added 3 new tests for group filtering behavior
- `app.py`: Auto-formatting by ruff

## Benefits
- **Faster filtering** - no network round-trip to BigQuery
- **Reduced database load** - fewer queries when exploring cached data
- **Better UX** - users can interactively filter results across groups without re-fetching

## Testing
- ✅ All 46 JavaScript tests pass (including 3 new group filter tests)
- ✅ All 16 Python tests pass  
- ✅ Linter passes with no errors
- ✅ Manually tested application startup

## How to Test
1. Search for builds without specifying a group (e.g., name="openshift-cli")
2. Observe results from multiple groups are cached
3. Change the Group field to a specific group (e.g., "openshift-4.16")
4. **Verify "Filter view" button appears**
5. Click "Filter view"
6. **Verify results are filtered client-side** (check Network tab - no new /search request)
7. **Verify only builds from selected group are displayed**

Fixes: https://redhat.atlassian.net/browse/ART-19650