### PR TITLE
ART-19651: Add wildcard support for group filtering (ART-19651)

### DIFF
--- a/app.py
+++ b/app.py
@@ -765,10 +765,21 @@ class KonfluxBuildHistory(Flask):
         self._logger.info('Search Parameters: %s, Outcomes: %s', params, outcomes)
 
         where_clauses = {}
+        extra_patterns = {}
+        warnings = []
 
-        group = params.get('group', '')
+        group = params.get('group', '').strip()
         if group:
-            where_clauses['group'] = group
+            # Support wildcards in group (e.g., "openshift-*")
+            if '*' in group:
+                # Convert shell-style wildcards to regex pattern
+                # Escape special regex chars except *, then replace * with .*
+                regex_pattern = re.escape(group).replace(r'\*', '.*')
+                # Anchor the pattern to match the full string (^pattern$)
+                extra_patterns['group'] = f'^{regex_pattern}$'
+            else:
+                # Exact match for non-wildcard groups
+                where_clauses['group'] = group
 
         assembly = params.get('assembly', '').strip()
         if assembly and assembly != '*':
@@ -786,9 +797,6 @@ class KonfluxBuildHistory(Flask):
         # Note: hermetic filtering happens client-side because search_builds_by_fields()
         # only supports REGEXP matching on extra_patterns, not Boolean filtering.
         # The hermetic parameter is passed through query params for client-side filtering.
-
-        extra_patterns = {}
-        warnings = []
 
         name = params.get('name', '').strip()
         if name:

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1101,8 +1101,20 @@ function matchesFilters(result, filterParams) {
             if (value === '*') {
                 continue; // Match all groups
             }
-            if (result['group'] != value) {
-                return false;
+            // Support wildcards in group (e.g., "openshift-*", "okd*")
+            if (value.includes('*')) {
+                // Convert shell-style wildcard to regex pattern
+                // Escape special regex chars except *, then replace * with .*
+                const regexPattern = value.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+                const regex = new RegExp('^' + regexPattern + '$');
+                if (!result['group'] || !regex.test(result['group'])) {
+                    return false;
+                }
+            } else {
+                // Exact match for non-wildcard groups
+                if (result['group'] != value) {
+                    return false;
+                }
             }
         } else if (key == 'record_id') {
             if (!result['record_id'] || result['record_id'] !== value) {
@@ -1700,9 +1712,9 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         }
 
-        // Apply hermetic and other client-side filters (e.g., hermetic, engine)
-        const formData = new FormData(form);
-        resultsToDisplay = resultsToDisplay.filter(result => matchesFilters(result, formData));
+        // Apply hermetic and other client-side filters (e.g., hermetic, engine, group)
+        // Use urlParams here since the form hasn't been populated from URL yet
+        resultsToDisplay = resultsToDisplay.filter(result => matchesFilters(result, urlParams));
 
         // Track what we're displaying from this search
         lastDisplayedResults = resultsToDisplay;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
                 <div class="input-container">
                     <label for="group">Group</label>
                     <div class="autocomplete-container">
-                        <input type="text" id="group" name="group" placeholder="Type to search branches..." autocomplete="off">
+                        <input type="text" id="group" name="group" placeholder="Type to search..." autocomplete="off" title="Supports wildcards: openshift-* matches all OpenShift groups, openshift-4.* matches 4.x versions">
                         <div id="group-dropdown" class="autocomplete-dropdown" style="display: none;"></div>
                     </div>
                 </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -425,3 +425,153 @@ async def test_query_extra_patterns():
                     assert captured_patterns['source_repo'] == 'openshift/oc'
                     assert captured_patterns['commitish'] == '^abc123'
                     assert captured_patterns['nvr'] == 'openshift-cli-4.15.0'
+
+
+@pytest.mark.asyncio
+async def test_query_group_exact_match():
+    """
+    Test that group without wildcards uses exact matching.
+    """
+    from app import KonfluxBuildHistory
+
+    with patch('artcommonlib.bigquery.BigQueryClient'):
+        with patch('artcommonlib.redis.get_value', return_value=None):
+            with patch('artcommonlib.redis.set_value'):
+                app_instance = KonfluxBuildHistory()
+
+                captured_where = {}
+                captured_patterns = {}
+
+                async def capture_params(**kwargs):
+                    captured_where.update(kwargs.get('where', {}))
+                    captured_patterns.update(kwargs.get('extra_patterns', {}))
+                    return
+                    yield  # Make this a generator
+
+                with patch('app.KonfluxDb') as mock_db:
+                    mock_instance = MagicMock()
+                    mock_instance.bind = MagicMock()
+                    mock_instance.search_builds_by_fields = MagicMock(side_effect=capture_params)
+                    mock_db.return_value = mock_instance
+
+                    params = {
+                        'group': 'openshift-4.15',
+                        'dateRange': '2024-01-15',
+                    }
+                    await app_instance.query(params)
+
+                    # Exact group should be in where clauses, not extra_patterns
+                    assert captured_where['group'] == 'openshift-4.15'
+                    assert 'group' not in captured_patterns
+
+
+@pytest.mark.asyncio
+async def test_query_group_wildcard_suffix():
+    """
+    Test that group with wildcard suffix (e.g., openshift-*) uses pattern matching.
+    """
+    from app import KonfluxBuildHistory
+
+    with patch('artcommonlib.bigquery.BigQueryClient'):
+        with patch('artcommonlib.redis.get_value', return_value=None):
+            with patch('artcommonlib.redis.set_value'):
+                app_instance = KonfluxBuildHistory()
+
+                captured_where = {}
+                captured_patterns = {}
+
+                async def capture_params(**kwargs):
+                    captured_where.update(kwargs.get('where', {}))
+                    captured_patterns.update(kwargs.get('extra_patterns', {}))
+                    return
+                    yield  # Make this a generator
+
+                with patch('app.KonfluxDb') as mock_db:
+                    mock_instance = MagicMock()
+                    mock_instance.bind = MagicMock()
+                    mock_instance.search_builds_by_fields = MagicMock(side_effect=capture_params)
+                    mock_db.return_value = mock_instance
+
+                    params = {
+                        'group': 'openshift-*',
+                        'dateRange': '2024-01-15',
+                    }
+                    await app_instance.query(params)
+
+                    # Wildcard group should be in extra_patterns as regex, not in where
+                    assert 'group' not in captured_where
+                    assert captured_patterns['group'] == '^openshift-.*$'
+
+
+@pytest.mark.asyncio
+async def test_query_group_wildcard_version():
+    """
+    Test that group with wildcard in version (e.g., openshift-4.*) uses pattern matching.
+    """
+    from app import KonfluxBuildHistory
+
+    with patch('artcommonlib.bigquery.BigQueryClient'):
+        with patch('artcommonlib.redis.get_value', return_value=None):
+            with patch('artcommonlib.redis.set_value'):
+                app_instance = KonfluxBuildHistory()
+
+                captured_where = {}
+                captured_patterns = {}
+
+                async def capture_params(**kwargs):
+                    captured_where.update(kwargs.get('where', {}))
+                    captured_patterns.update(kwargs.get('extra_patterns', {}))
+                    return
+                    yield  # Make this a generator
+
+                with patch('app.KonfluxDb') as mock_db:
+                    mock_instance = MagicMock()
+                    mock_instance.bind = MagicMock()
+                    mock_instance.search_builds_by_fields = MagicMock(side_effect=capture_params)
+                    mock_db.return_value = mock_instance
+
+                    params = {
+                        'group': 'openshift-4.*',
+                        'dateRange': '2024-01-15',
+                    }
+                    await app_instance.query(params)
+
+                    # Wildcard version should be regex pattern
+                    assert 'group' not in captured_where
+                    assert captured_patterns['group'] == r'^openshift-4\..*$'
+
+
+@pytest.mark.asyncio
+async def test_query_group_wildcard_special_chars():
+    """
+    Test that group wildcards with special regex chars are properly escaped.
+    """
+    from app import KonfluxBuildHistory
+
+    with patch('artcommonlib.bigquery.BigQueryClient'):
+        with patch('artcommonlib.redis.get_value', return_value=None):
+            with patch('artcommonlib.redis.set_value'):
+                app_instance = KonfluxBuildHistory()
+
+                captured_patterns = {}
+
+                async def capture_params(**kwargs):
+                    captured_patterns.update(kwargs.get('extra_patterns', {}))
+                    return
+                    yield  # Make this a generator
+
+                with patch('app.KonfluxDb') as mock_db:
+                    mock_instance = MagicMock()
+                    mock_instance.bind = MagicMock()
+                    mock_instance.search_builds_by_fields = MagicMock(side_effect=capture_params)
+                    mock_db.return_value = mock_instance
+
+                    # Test with group containing dots and dashes (common regex special chars)
+                    params = {
+                        'group': 'test-group-*',
+                        'dateRange': '2024-01-15',
+                    }
+                    await app_instance.query(params)
+
+                    # Special chars should be escaped, * should become .*
+                    assert captured_patterns['group'] == r'^test\-group\-.*$'


### PR DESCRIPTION
Enable users to search for builds using wildcards in the group field, such as "openshift-*" to match all OpenShift groups or "openshift-4.*" to match specific major versions.