### PR TITLE
Fix URL parameter search initialization and clean up empty params

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1742,6 +1742,34 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const form = document.getElementById("searchForm");
 
+    // CRITICAL: Setup checkboxes from URL params BEFORE performing any search
+    // This ensures that URL parameters are properly applied to multi-select fields
+    normalizeOutcomeCheckboxValues();
+
+    // Setup Outcome multi-select
+    setupMultiSelect('outcome-container', 'outcome-display', 'outcome-dropdown');
+    setupMultiSelect('buildtype-container', 'buildtype-display', 'buildtype-dropdown', updateBuildTypeDisplay, getBuildTypeCheckboxes);
+
+    // Set outcome checkboxes from URL if present
+    if (urlParams.has('outcome')) {
+        const outcomes = urlParams.getAll('outcome');
+        const checkboxes = getOutcomeCheckboxes();
+        checkboxes.forEach(cb => {
+            cb.checked = outcomes.includes(getOutcomeValue(cb));
+        });
+        updateOutcomeDisplay();
+    }
+
+    // Set buildtype checkboxes from URL if present
+    if (urlParams.has('buildtype')) {
+        const buildtypes = urlParams.getAll('buildtype');
+        const buildtypeCheckboxes = getBuildTypeCheckboxes();
+        buildtypeCheckboxes.forEach(cb => {
+            cb.checked = buildtypes.includes(cb.value);
+        });
+        updateBuildTypeDisplay();
+    }
+
     // If we have initial results from server, cache raw results and deduplicate for display
     if (isSearchPage && window.initialResults) {
         // Cache raw results from server (all outcomes)
@@ -1775,14 +1803,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     // Otherwise, if we have search parameters, perform search
     else if (urlParams.size > 0) {
-        // Populate form fields from URL
+        // Populate form fields from URL (non-checkbox fields)
         urlParams.forEach((value, key) => {
+            // Skip checkbox fields - they're already set above
+            if (key === 'outcome' || key === 'buildtype') return;
+
             const input = form.querySelector(`[name="${key}"]`);
             if (input) input.value = value;
         });
 
-        performSearch(urlParams);
-        lastSearchParamsKey = buildParamsKey(urlParams);
+        // Don't pass urlParams directly - let performSearch() read from the form
+        // which now has all fields (including checkboxes) properly set
+        performSearch();
+        lastSearchParamsKey = buildParamsKey(getCurrentSearchParams());
     }
     else {
         lastSearchParamsKey = buildParamsKey(getCurrentSearchParams());
@@ -1845,32 +1878,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const assemblyDropdown = document.getElementById("assembly-dropdown");
     const assemblyOptions = ["stream", "test", "*"];
     setupStaticAutocomplete(assemblyInput, assemblyDropdown, assemblyOptions);
-
-    normalizeOutcomeCheckboxValues();
-
-    // Setup Outcome multi-select
-    setupMultiSelect('outcome-container', 'outcome-display', 'outcome-dropdown');
-    setupMultiSelect('buildtype-container', 'buildtype-display', 'buildtype-dropdown', updateBuildTypeDisplay, getBuildTypeCheckboxes);
-
-    // Set outcome checkboxes from URL if present
-    if (urlParams.has('outcome')) {
-        const outcomes = urlParams.getAll('outcome');
-        const checkboxes = getOutcomeCheckboxes();
-        checkboxes.forEach(cb => {
-            cb.checked = outcomes.includes(getOutcomeValue(cb));
-        });
-        updateOutcomeDisplay();
-    }
-
-    // Set buildtype checkboxes from URL if present
-    if (urlParams.has('buildtype')) {
-        const buildtypes = urlParams.getAll('buildtype');
-        const buildtypeCheckboxes = getBuildTypeCheckboxes();
-        buildtypeCheckboxes.forEach(cb => {
-            cb.checked = buildtypes.includes(cb.value);
-        });
-        updateBuildTypeDisplay();
-    }
 });
 
 document.getElementById("searchButton").addEventListener("click", function (event) {
@@ -1878,7 +1885,14 @@ document.getElementById("searchButton").addEventListener("click", function (even
 
     const form = document.getElementById("searchForm");
     const formData = new FormData(form);
-    const queryParams = new URLSearchParams(formData);
+
+    // Build clean query params - exclude empty values
+    const queryParams = new URLSearchParams();
+    for (const [key, value] of formData.entries()) {
+        if (value && value.trim() !== '') {
+            queryParams.append(key, value);
+        }
+    }
 
     // Update browser URL without reloading
     window.history.pushState({}, '', `/?${queryParams.toString()}`);


### PR DESCRIPTION
## Problem
When pasting a URL with search parameters in a new browser window, the search would return no results. This happened because multi-select checkboxes (outcome and buildtype) were being initialized **after** the search was performed, causing the search to use default checkbox values instead of the URL parameter values.

For example, pasting this URL would return no results:
```
https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=ose-machine-os-images&group=okd-5.0&assembly=stream&outcome=Success&outcome=Failure&engine=konflux&hermetic=both&buildtype=image&buildtype=bundle&buildtype=fbc&dateRange=2026-06-30+to+2026-07-07&nvr=&record_id=&image_sha_tag=&source_repo=&commitish=&art-job-url=
```

## Root Cause
In `static/js/index.js`, the DOMContentLoaded event handler was:
1. Loading the page with URL params
2. **Performing the search immediately** (line ~1812)
3. **Then setting the checkboxes** from URL params (lines ~1850-1870)

This meant the search used default checkbox values (only "Success" checked) instead of the URL values.

## Solution

### 1. Fix checkbox initialization order
- Moved the checkbox initialization code to run **before** the search is performed
- Ensured URL parameters are properly applied to all form fields before any database query
- Changed `performSearch(urlParams)` to `performSearch()` so it reads from the form (which now has checkboxes properly set)

### 2. Clean up URL parameters
- Modified the search button handler to exclude empty parameters from the URL
- Removes clutter like `&art-job-url=` from URLs
- Makes shared URLs cleaner and easier to read